### PR TITLE
Fix: changed starting date on CTA

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -54,7 +54,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-line-lrg">
             <span class="whitetext">Summer Fun for Kids</span>
           </div>
-          <div class="cta-line-sml">22 - 26 April 2025 • Register Now!</div>
+          <div class="cta-line-sml">21 - 26 April 2025 • Register Now!</div>
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
 
@@ -91,7 +91,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-line-lrg">
             <span class="whitetext">Summer Fun for Kids</span>
           </div>
-          <div class="cta-line-sml">22 - 26 April 2025 • Register Now!</div>
+          <div class="cta-line-sml">21 - 26 April 2025 • Register Now!</div>
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
       </div>
@@ -134,7 +134,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-line-lrg">
             <span class="whitetext">Summer Fun for Kids</span>
           </div>
-          <div class="cta-line-sml">22 - 26 April 2025 • Register Now!</div>
+          <div class="cta-line-sml">21 - 26 April 2025 • Register Now!</div>
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
       </div>
@@ -177,7 +177,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-line-lrg">
             <span class="whitetext">Summer Fun for Kids</span>
           </div>
-          <div class="cta-line-sml">22 - 26 April 2025 • Register Now!</div>
+          <div class="cta-line-sml">21 - 26 April 2025 • Register Now!</div>
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
       </div>
@@ -222,7 +222,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-line-lrg">
             <span class="whitetext">Summer Fun for Kids</span>
           </div>
-          <div class="cta-line-sml">22 - 26 April 2025 • Register Now!</div>
+          <div class="cta-line-sml">21 - 26 April 2025 • Register Now!</div>
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
       </div>
@@ -267,7 +267,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-line-lrg">
             <span class="whitetext">Summer Fun for Kids</span>
           </div>
-          <div class="cta-line-sml">22 - 26 April 2025 • Register Now!</div>
+          <div class="cta-line-sml">21 - 26 April 2025 • Register Now!</div>
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
       </div>
@@ -312,7 +312,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-line-lrg">
             <span class="whitetext">Summer Fun for Kids</span>
           </div>
-          <div class="cta-line-sml">22 - 26 April 2025 • Register Now!</div>
+          <div class="cta-line-sml">21 - 26 April 2025 • Register Now!</div>
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
       </div>
@@ -356,7 +356,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-line-lrg">
             <span class="whitetext">Summer Fun for Kids</span>
           </div>
-          <div class="cta-line-sml">22 - 26 April 2025 • Register Now!</div>
+          <div class="cta-line-sml">21 - 26 April 2025 • Register Now!</div>
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
       </div>
@@ -400,7 +400,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-line-lrg">
             <span class="whitetext">Summer Fun for Kids</span>
           </div>
-          <div class="cta-line-sml">22 - 26 April 2025 • Register Now!</div>
+          <div class="cta-line-sml">21 - 26 April 2025 • Register Now!</div>
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
       </div>
@@ -444,7 +444,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-line-lrg">
             <span class="whitetext">Summer Fun for Kids</span>
           </div>
-          <div class="cta-line-sml">22 - 26 April 2025 • Register Now!</div>
+          <div class="cta-line-sml">21 - 26 April 2025 • Register Now!</div>
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
       </div>
@@ -512,7 +512,7 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
     ["200"] %}
     <div class="cta-textbox">
       <div class="cta-line-lrg">Summer Fun for Kids</div>
-      <div class="cta-line-sml">22 - 26 April 2025</div>
+      <div class="cta-line-sml">21 - 26 April 2025</div>
       <div class="cta-line-sml">Register now!</div>
     </div>
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the "Summer Fun for Kids" event date so it now displays a range of "21 - 26 April 2025" consistently across all sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->