### PR TITLE
Fix: redirected village/trustees  to board/

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -383,6 +383,12 @@ status = 301
 force = true
 
 [[redirects]]
+from = "/village/trustees*"
+to = "/board"
+status = 301
+force = true
+
+[[redirects]]
 from = "/wisdom/workshops/*"
 to = "/gurukula"
 status = 301

--- a/netlify/functions/preview/src/index.njk
+++ b/netlify/functions/preview/src/index.njk
@@ -49,14 +49,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
         </div>
         -->
-        <div class="cta-mobile"
-             onclick="location.href='/summer-workshop';">
-          <div class="cta-line-lrg">
-            <span class="whitetext">Summer Workshop&nbsp; 01 - 12 July 2025</span>
-          </div>
-          <div class="cta-line-sml">Deadline: 27 April 2025 • Register Now!</div>
-          <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
-        </div>
 
       </div>
     </div>
@@ -86,14 +78,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
         </span>
         </div>
         <!-- CTA Box for Mobile Here -->
-        <div class="cta-mobile"
-             onclick="location.href='/summer-workshop';">
-          <div class="cta-line-lrg">
-            <span class="whitetext">Summer Workshop&nbsp; 01 - 12 July 2025</span>
-          </div>
-          <div class="cta-line-sml">Deadline: 27 April 2025 • Register Now!</div>
-          <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
-        </div>
       </div>
     </div>
     {# Slide 3 #}
@@ -129,14 +113,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
         </span>
         </div>
         <!-- CTA Box for Mobile Here -->
-        <div class="cta-mobile"
-             onclick="location.href='/summer-workshop';">
-          <div class="cta-line-lrg">
-            <span class="whitetext">Summer Workshop&nbsp; 01 - 12 July 2025</span>
-          </div>
-          <div class="cta-line-sml">Deadline: 27 April 2025 • Register Now!</div>
-          <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
-        </div>
       </div>
     </div>
     {# Slide 4 #}
@@ -172,14 +148,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
         </span>
         </div>
         <!-- CTA Box for Mobile Here -->
-        <div class="cta-mobile"
-             onclick="location.href='/summer-workshop';">
-          <div class="cta-line-lrg">
-            <span class="whitetext">Summer Workshop&nbsp; 01 - 12 July 2025</span>
-          </div>
-          <div class="cta-line-sml">Deadline: 27 April 2025 • Register Now!</div>
-          <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
-        </div>
       </div>
 
     </div>
@@ -217,14 +185,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
         </span>
         </div>
         <!-- CTA Box for Mobile Here -->
-        <div class="cta-mobile"
-             onclick="location.href='/summer-workshop';">
-          <div class="cta-line-lrg">
-            <span class="whitetext">Summer Workshop&nbsp; 01 - 12 July 2025</span>
-          </div>
-          <div class="cta-line-sml">Deadline: 27 April 2025 • Register Now!</div>
-          <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
-        </div>
       </div>
 
     </div>
@@ -262,14 +222,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
           </span>
         </div>
         <!-- CTA Box for Mobile Here -->
-        <div class="cta-mobile"
-             onclick="location.href='/summer-workshop';">
-          <div class="cta-line-lrg">
-            <span class="whitetext">Summer Workshop&nbsp; 01 - 12 July 2025</span>
-          </div>
-          <div class="cta-line-sml">Deadline: 27 April 2025 • Register Now!</div>
-          <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
-        </div>
       </div>
 
     </div>
@@ -307,14 +259,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
         </span>
         </div>
         <!-- CTA Box for Mobile Here -->
-        <div class="cta-mobile"
-             onclick="location.href='/summer-workshop';">
-          <div class="cta-line-lrg">
-            <span class="whitetext">Summer Workshop&nbsp; 01 - 12 July 2025</span>
-          </div>
-          <div class="cta-line-sml">Deadline: 27 April 2025 • Register Now!</div>
-          <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
-        </div>
       </div>
 
     </div>
@@ -351,14 +295,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
         </span>
         </div>
         <!-- CTA Box for Mobile Here -->
-        <div class="cta-mobile"
-             onclick="location.href='/summer-workshop';">
-          <div class="cta-line-lrg">
-            <span class="whitetext">Summer Workshop&nbsp; 01 - 12 July 2025</span>
-          </div>
-          <div class="cta-line-sml">Deadline: 27 April 2025 • Register Now!</div>
-          <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
-        </div>
       </div>
 
     </div>
@@ -395,14 +331,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
         </span>
         </div>
         <!-- CTA Box for Mobile Here -->
-        <div class="cta-mobile"
-             onclick="location.href='/summer-workshop';">
-          <div class="cta-line-lrg">
-            <span class="whitetext">Summer Workshop&nbsp; 01 - 12 July 2025</span>
-          </div>
-          <div class="cta-line-sml">Deadline: 27 April 2025 • Register Now!</div>
-          <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
-        </div>
       </div>
 
     </div>
@@ -439,14 +367,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
         </span>
         </div>
         <!-- CTA Box for Mobile Here -->
-        <div class="cta-mobile"
-             onclick="location.href='/summer-workshop';">
-          <div class="cta-line-lrg">
-            <span class="whitetext">Summer Workshop&nbsp; 01 - 12 July 2025</span>
-          </div>
-          <div class="cta-line-sml">Deadline: 27 April 2025 • Register Now!</div>
-          <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
-        </div>
       </div>
 
     </div>
@@ -505,17 +425,6 @@ OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo
     </div>
   </div>
 -->
-  <div class="cta-desk"
-       onclick="location.href='/summer-workshop';">
-    {% image "https://res.cloudinary.com/nrityagram/image/upload/v1743082932/summer-workshop-cta_asluao.png",
-    "Summer Workshop picture",
-    ["200"], "200px", "eager" %}
-    <div class="cta-textbox">
-      <div class="cta-line-lrg">Summer Workshop</div>
-      <div class="cta-line-sml">01 - 12 July 2025</div>
-      <div class="cta-line-sml">Deadline: 27 Apr 2025&nbsp; Register Now!</div>
-    </div>
-  </div>
 
   <!-- close vanilla-slideshow-container -->
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a redirect so that requests to "/village/trustees" are now redirected to "/board".
- **Refactor**
  - Removed all mobile and desktop call-to-action boxes related to the "Summer Workshop 01 - 12 July 2025" from the relevant page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->