### PR TITLE
Modifying canonical link in page header

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -51,7 +51,7 @@
 		<meta name="twitter:description" content="{{ description or metadata.description }}">
 		<meta name="twitter:image" content="{{ OGImage or metadata.OGImage }}">
 		<meta name="twitter:image:alt" content="Nrityagram OpenGraph Image">
-		<link rel="canonical" href="https://nrityagram.org">
+		<link rel="canonical" href="https://nrityagram.org{{ page.url }}">
 
 		<!-- openprops -->
 		<!-- <link rel="stylesheet" href="https://unpkg.com/open-props" /> -->


### PR DESCRIPTION
The canonical link has been updated to include the current page's slug using {{ page.url }}. This will dynamically generate the correct canonical URL for each page, including the page's path/slug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Canonical URLs now reflect each page instead of defaulting to the homepage, improving SEO accuracy, reducing duplicate content issues, and ensuring correct indexing and link previews across the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->