### PR TITLE
feat(donation): update fiscal sponsor to Phoenix Theatre Ensemble

### DIFF
--- a/netlify/functions/preview/src/makeadonation-usa.njk
+++ b/netlify/functions/preview/src/makeadonation-usa.njk
@@ -23,7 +23,7 @@ description: "Any amount you donate will make it possible for us to strengthen o
       <div class="credit" data-image-credit="Guillermo Consejo" ></div>
     </div>
     <p>
-      You will donate via our fiscal sponsor <a href="http://phoenixtheatreensemble.org/" target="_blank" class="bodylink">
+      You will donate via our fiscal sponsor <a href="https://phoenixtheatreensemble.org/" target="_blank" class="bodylink">
         <em>Phoenix Theatre Ensemble</em>
       </a>.
     </p>

--- a/netlify/functions/preview/src/makeadonation-usa.njk
+++ b/netlify/functions/preview/src/makeadonation-usa.njk
@@ -23,19 +23,31 @@ description: "Any amount you donate will make it possible for us to strengthen o
       <div class="credit" data-image-credit="Guillermo Consejo" ></div>
     </div>
     <p>
-      You will donate via our fiscal sponsor <a href="https://www.pentacle.org" target="_blank" class="bodylink">
-        <em>Dance Works, Inc.</em> DBA <em>Pentacle</em>
+      You will donate via our fiscal sponsor <a href="http://phoenixtheatreensemble.org/" target="_blank" class="bodylink">
+        <em>Phoenix Theatre Ensemble</em>
       </a>.
     </p>
     <p>
-      Pentacle (Dance Works Inc.) is a 501(c)(3) not-for-profit organization EIN # 23-7426261.
+      Phoenix Theatre Ensemble is a 501(c)(3) not-for-profit organization EIN # 20-1562809.
       <br />
       Your contribution is <strong>tax-deductible</strong> to the fullest extent allowed by law.   
     </p>
-    <p>
+    {# <p>
        Once you are done, click on return to Dance Works, Inc. DBA Pentacle; you will return to our website.
-    </p>
-    <p>
+    </p> #}
+    
+    <div  class="centerflex">
+      <img
+      class="hot-spot"
+      src="https://res.cloudinary.com/nrityagram/image/upload/v1701072823/ng-donate-now-paypal_zg0qwu.png" 
+      alt="Donate Now with PayPal" 
+      width="230" 
+      onclick="window.open('https://www.paypal.com/ncp/payment/WLUHLYNLVE5CG',
+  '_blank')"
+      style="cursor: pointer;"/>
+    </div>
+    
+    {# <p>
       <form action="https://www.paypal.com/cgi-bin/webscr"
       method="post"
       target="_top" class="center" >
@@ -53,7 +65,7 @@ description: "Any amount you donate will make it possible for us to strengthen o
         width="1"
         height="1" />
       </form>
-    </p>
+    </p> #}
     <br />
   </div>
 </div>

--- a/netlify/functions/preview/src/sass/base/_base.scss
+++ b/netlify/functions/preview/src/sass/base/_base.scss
@@ -50,7 +50,6 @@ h3 {
 	color: hsl(var(--clr-secondary-550));
 }
 
-
 h4 {
 	color: hsl(var(--clr-neutral-850));
 }
@@ -67,7 +66,7 @@ h1 {
 	}
 }
 
-// for portable txt style 
+// for portable txt style
 .medium-wt {
 	font-weight: var(--fw-serif-medium);
 }
@@ -98,11 +97,11 @@ h4 {
 	}
 }
 
-h1+h3 {
+h1 + h3 {
 	margin-top: 0 !important;
 }
 
-h2+h4 {
+h2 + h4 {
 	margin-top: 0 !important;
 }
 
@@ -161,7 +160,10 @@ s {
 
 .centerflex {
 	display: flex;
-	justify-content: center
+	justify-content: center;
+	&.fitwidth {
+		width: fit-content;
+	}
 }
 
 .right {

--- a/src/makeadonation-usa.njk
+++ b/src/makeadonation-usa.njk
@@ -23,7 +23,7 @@ description: "Any amount you donate will make it possible for us to strengthen o
       <div class="credit" data-image-credit="Guillermo Consejo" ></div>
     </div>
     <p>
-      You will donate via our fiscal sponsor <a href="http://phoenixtheatreensemble.org/" target="_blank" class="bodylink">
+      You will donate via our fiscal sponsor <a href="https://phoenixtheatreensemble.org/" target="_blank" class="bodylink">
         <em>Phoenix Theatre Ensemble</em>
       </a>.
     </p>

--- a/src/makeadonation-usa.njk
+++ b/src/makeadonation-usa.njk
@@ -23,19 +23,31 @@ description: "Any amount you donate will make it possible for us to strengthen o
       <div class="credit" data-image-credit="Guillermo Consejo" ></div>
     </div>
     <p>
-      You will donate via our fiscal sponsor <a href="https://www.pentacle.org" target="_blank" class="bodylink">
-        <em>Dance Works, Inc.</em> DBA <em>Pentacle</em>
+      You will donate via our fiscal sponsor <a href="http://phoenixtheatreensemble.org/" target="_blank" class="bodylink">
+        <em>Phoenix Theatre Ensemble</em>
       </a>.
     </p>
     <p>
-      Pentacle (Dance Works Inc.) is a 501(c)(3) not-for-profit organization EIN # 23-7426261.
+      Phoenix Theatre Ensemble is a 501(c)(3) not-for-profit organization EIN # 20-1562809.
       <br />
       Your contribution is <strong>tax-deductible</strong> to the fullest extent allowed by law.   
     </p>
-    <p>
+    {# <p>
        Once you are done, click on return to Dance Works, Inc. DBA Pentacle; you will return to our website.
-    </p>
-    <p>
+    </p> #}
+    
+    <div  class="centerflex">
+      <img
+      class="hot-spot"
+      src="https://res.cloudinary.com/nrityagram/image/upload/v1701072823/ng-donate-now-paypal_zg0qwu.png" 
+      alt="Donate Now with PayPal" 
+      width="230" 
+      onclick="window.open('https://www.paypal.com/ncp/payment/WLUHLYNLVE5CG',
+  '_blank')"
+      style="cursor: pointer;"/>
+    </div>
+    
+    {# <p>
       <form action="https://www.paypal.com/cgi-bin/webscr"
       method="post"
       target="_top" class="center" >
@@ -53,7 +65,7 @@ description: "Any amount you donate will make it possible for us to strengthen o
         width="1"
         height="1" />
       </form>
-    </p>
+    </p> #}
     <br />
   </div>
 </div>

--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -50,7 +50,6 @@ h3 {
 	color: hsl(var(--clr-secondary-550));
 }
 
-
 h4 {
 	color: hsl(var(--clr-neutral-850));
 }
@@ -67,7 +66,7 @@ h1 {
 	}
 }
 
-// for portable txt style 
+// for portable txt style
 .medium-wt {
 	font-weight: var(--fw-serif-medium);
 }
@@ -98,11 +97,11 @@ h4 {
 	}
 }
 
-h1+h3 {
+h1 + h3 {
 	margin-top: 0 !important;
 }
 
-h2+h4 {
+h2 + h4 {
 	margin-top: 0 !important;
 }
 
@@ -161,7 +160,10 @@ s {
 
 .centerflex {
 	display: flex;
-	justify-content: center
+	justify-content: center;
+	&.fitwidth {
+		width: fit-content;
+	}
 }
 
 .right {


### PR DESCRIPTION
Update the donation page to reflect the change in fiscal sponsorship from Pentacle to Phoenix Theatre Ensemble. This includes updating the organization name, website URL, and EIN number. Additionally, replaced the old PayPal form with a new direct link button and added a `fitwidth` modifier utility class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centered, clickable PayPal image button to open the donation flow in a new tab.

* **Bug Fixes**
  * Corrected CSS syntax and minor formatting issues for layout consistency.

* **Updates**
  * Updated fiscal sponsor details from the previous organization to Phoenix Theatre Ensemble, including revised display and tax ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->