### PR TITLE
Summer Fun for Kids updates for 2026

### DIFF
--- a/netlify/functions/preview/src/_includes/cta-desk.njk
+++ b/netlify/functions/preview/src/_includes/cta-desk.njk
@@ -6,7 +6,7 @@
          loading="lazy">
     <div class="cta-textbox">
         <div class="cta-line-lrg">Summer Fun for Kids</div>
-        <div class="cta-line-sml">13 - 18 April 2026</div>
+        <div class="cta-line-sml">28 April - 3 May 2026</div>
         <div class="cta-line-sml">Registrations Open</div>
     </div>
 </div>

--- a/netlify/functions/preview/src/_includes/cta-desk.njk
+++ b/netlify/functions/preview/src/_includes/cta-desk.njk
@@ -1,12 +1,12 @@
 <div class="cta-desk"
-       onclick="location.href='/virtual-steps';">
-    <img src="https://res.cloudinary.com/nrityagram/image/upload/w_200/v1748004445/virtual-steps-cta_yp7fcg.png"
-         alt="Virtual Steps CTA picture"
+       onclick="location.href='/summer-fun-for-kids';">
+    <img src="https://res.cloudinary.com/nrityagram/image/upload/v1739448387/summer-fun-cta_v2i7bb.png"
+         alt="Summer Fun for Kids 2026 picture"
          width="200"
          loading="lazy">
     <div class="cta-textbox">
-        <div class="cta-line-lrg">Virtual Steps</div>
-        <div class="cta-line-sml">New Batch Starts on 5 July 2025</div>
-        <div class="cta-line-sml">Registration Closed</div>
+        <div class="cta-line-lrg">Summer Fun for Kids</div>
+        <div class="cta-line-sml">13 - 18 April 2026</div>
+        <div class="cta-line-sml">Registrations Open</div>
     </div>
 </div>

--- a/netlify/functions/preview/src/_includes/cta-mobile.njk
+++ b/netlify/functions/preview/src/_includes/cta-mobile.njk
@@ -3,6 +3,6 @@
     <div class="cta-line-lrg">
         <span class="whitetext">Summer Fun for Kids</span>
     </div>
-    <div class="cta-line-sml">13 - 18 April 2026 • Registrations Open</div>
+    <div class="cta-line-sml">28 April - 3 May 2026 • Registrations Open</div>
     <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
 </div>

--- a/netlify/functions/preview/src/_includes/cta-mobile.njk
+++ b/netlify/functions/preview/src/_includes/cta-mobile.njk
@@ -1,8 +1,8 @@
 <div class="cta-mobile"
-             onclick="location.href='/virtual-steps';">
+             onclick="location.href='/summer-fun-for-kids';">
     <div class="cta-line-lrg">
-        <span class="whitetext">Virtual Steps</span>
+        <span class="whitetext">Summer Fun for Kids</span>
     </div>
-    <div class="cta-line-sml">New Batch starts on 5 July 2025 • Registration Closed</div>
+    <div class="cta-line-sml">13 - 18 April 2026 • Registrations Open</div>
     <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
 </div>

--- a/netlify/functions/preview/src/danceunlimited.njk
+++ b/netlify/functions/preview/src/danceunlimited.njk
@@ -71,21 +71,10 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1717245209/d
     </div>
     <h2 class="center">Summer Fun for Kids</h2>
     <p>
-			Our Summer Fun for Kids is a unique residential workshop designed to help young ones understand community
-			living. Every year a small group of children enrol in this workshop to find out for themselves,
-			what is the Nrityagram way of life. Far away from television sets and video games, surrounded by lush foliage,
-			beautiful birds and flowering trees, they experience life in a place where all residents take care of themselves
-			and their home, and the cornerstone for the entire community is mindful living and the pursuit of excellence. 
+      <b>Summer Fun for Kids</b> is a residential workshop that offers children a glimpse into the Nrityagram way of life. Surrounded by nature and away from everyday distractions, participants spend their days immersed in dance while experiencing the rhythms of community living. Along with dance sessions, children enjoy nature walks, storytelling, games, and creative exploration. For many participants - and their parents - the experience becomes truly <b>life-changing</b>. 
 		</p>
     <p>
-			The focus is dance but they also go for
-			nature walks, tell stories, play games and most importantly, have lots of fun.
-		</p>
-    <p>	
-			Most of the children (and their parents) describe the experience as “life changing”.
-		</p>
-    <p>
-      <a href="/summer-fun-for-kids" class="bodylink">Summer Fun for Kids 2025</a>
+      <a href="/summer-fun-for-kids" class="bodylink">Summer Fun for Kids 2026</a>
     </p>
     <div class="image-plus top-flow">
       {% image "https://res.cloudinary.com/nrityagram/image/upload/c_scale,w_800/v1580737468/3_NG101_r33pqg.jpg",

--- a/netlify/functions/preview/src/danceunlimited.njk
+++ b/netlify/functions/preview/src/danceunlimited.njk
@@ -69,7 +69,12 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1717245209/d
       ["560", "768", "1046"] %}
       <div class="credit" data-image-credit="Dhruvatara Sharma" ></div>
     </div>
-    <h2 class="center">Summer Fun for Kids</h2>
+    <span class="center">
+      <h2>Summer Fun for Kids</h2>
+      <h4>
+      Live. Move. Discover.
+    </h4>
+    </span>
     <p>
       <b>Summer Fun for Kids</b> is a residential workshop that offers children a glimpse into the Nrityagram way of life. Surrounded by nature and away from everyday distractions, participants spend their days immersed in dance while experiencing the rhythms of community living. Along with dance sessions, children enjoy nature walks, storytelling, games, and creative exploration. For many participants - and their parents - the experience becomes truly <b>life-changing</b>. 
 		</p>

--- a/netlify/functions/preview/src/friendsofng.njk
+++ b/netlify/functions/preview/src/friendsofng.njk
@@ -10,6 +10,7 @@ parentMenuItem: "Support"
 title: "Friends of Nrityagram"
 description: "Friends of Nrityagram are vital members of our extended family. Your support will help us maintain the institution and further expand it. India’s first modern Gurukul, Nrityagram is a one-of-a-kind community where dance is a way of life."
 OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1570033516/friends-of-nrityagram-banner_fg7kzg.jpg"
+archive: true
 ---
 <div id="banner-container">
   <div class="banner-image">

--- a/netlify/functions/preview/src/index.njk
+++ b/netlify/functions/preview/src/index.njk
@@ -9,7 +9,7 @@ slider: true
 youtube: true
 marquee: true
 scrollToTop: true
-cta: false
+cta: true
 date: Last Modified
 OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo_blk_bg_sg0emm.png'
 ---

--- a/netlify/functions/preview/src/informance.njk
+++ b/netlify/functions/preview/src/informance.njk
@@ -8,6 +8,7 @@ date: Last Modified
 title: "Informance"
 description: "Fun and interesting activities to do in Nrityagram - guided tours and lecture-demonstrations."
 OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1731612495/nov2024-informance-desk_yy24de.png"
+archive: true
 ---
 <div id="banner-container">
   <div class="banner-image">

--- a/netlify/functions/preview/src/makeadonation-usa.njk
+++ b/netlify/functions/preview/src/makeadonation-usa.njk
@@ -28,7 +28,8 @@ description: "Any amount you donate will make it possible for us to strengthen o
       </a>.
     </p>
     <p>
-      Phoenix Theatre Ensemble is a 501(c)(3) not-for-profit organization EIN # 20-1562809.
+      <!-- Break up the number formatting to prevent safari from automatically detecting the EIN number as a phone number -->
+      Phoenix Theatre Ensemble is a 501(c)(3) not-for-profit organization EIN # 20-1562<span style="display:none;">.</span>809.
     </p>
     <p>
       Your contribution is <strong>tax-deductible</strong> to the fullest extent allowed by law.   

--- a/netlify/functions/preview/src/makeadonation-usa.njk
+++ b/netlify/functions/preview/src/makeadonation-usa.njk
@@ -28,8 +28,8 @@ description: "Any amount you donate will make it possible for us to strengthen o
       </a>.
     </p>
     <p>
-      <!-- Break up the number formatting to prevent safari from automatically detecting the EIN number as a phone number -->
-      Phoenix Theatre Ensemble is a 501(c)(3) not-for-profit organization EIN # 20-1562<span style="display:none;">.</span>809.
+      <!-- Wrap the number in semantic tags to prevent safari from automatically detecting the EIN number as a phone number -->
+      Phoenix Theatre Ensemble is a 501(c)(3) not-for-profit organization EIN # <code>20-1562809</code>.
     </p>
     <p>
       Your contribution is <strong>tax-deductible</strong> to the fullest extent allowed by law.   

--- a/netlify/functions/preview/src/robots.njk
+++ b/netlify/functions/preview/src/robots.njk
@@ -5,5 +5,10 @@ permalink: /robots.txt
 User-agent: *
 Allow: /
 Disallow: /pagetemplate
+{%- for page in collections.all %}
+{%- if page.data.archive %}
+Disallow: {{ page.url }}
+{%- endif %}
+{%- endfor %}
 
 Sitemap: {{ metadata.url }}/sitemap.xml

--- a/netlify/functions/preview/src/sass/utilities/_columns.scss
+++ b/netlify/functions/preview/src/sass/utilities/_columns.scss
@@ -2,432 +2,411 @@
 @use 'flow' as *;
 @use '../abstracts/' as *;
 
-
 .left-column {
-    grid-area: leftcol;
+	grid-area: leftcol;
 }
 
 .right-column {
-    grid-area: rightcol;
+	grid-area: rightcol;
 }
 
 .narrow-column {
-    grid-area: narrowcol;
+	grid-area: narrowcol;
 
-    @include mqmax(medium) {
-        align-self: center;
-    }
+	@include mqmax(medium) {
+		align-self: center;
+	}
 }
 
 .narrow-column :where(:not(:first-child)) {
-    margin-top: var(--flow-spacer-close);
+	margin-top: var(--flow-spacer-close);
 }
 
 .wide-column {
-    grid-area: widecol;
+	grid-area: widecol;
 
-    @include mqmax(medium) {
-        align-self: center;
-    }
+	@include mqmax(medium) {
+		align-self: center;
+	}
 }
 
 .spacer-column {
-    grid-area: spacercol;
+	grid-area: spacercol;
 }
 
 .center-column {
-    padding-left: 25%;
-    padding-right: 25%;
+	padding-left: 25%;
+	padding-right: 25%;
 
-    @include mqmax(medium) {
-        padding-left: 0;
-        padding-right: 0;
-    }
+	@include mqmax(medium) {
+		padding-left: 0;
+		padding-right: 0;
+	}
 }
-
 
 // TODO: make a sass/layouts folder to implement specific layout designs such pullquote-column, narrow-wide-40-60, etc.
 
 .even-columns-unlimited {
-    @extend .grid;
-    place-items: center;
+	@extend .grid;
+	place-items: center;
 
-    // For ipad mini (portrait) we want slideup cards to appear 2x2,
-    // hence a different medium berakpoint at 720px instead of 800px
-    @include mq(medium2) {
-        grid-template-columns: repeat(2, 1fr);
-    }
+	// For ipad mini (portrait) we want slideup cards to appear 2x2,
+	// hence a different medium berakpoint at 720px instead of 800px
+	@include mq(medium2) {
+		grid-template-columns: repeat(2, 1fr);
+	}
 
-    @include mq(large2) {
-        grid-auto-flow: column;
-        grid-auto-columns: 1fr;
-    }
+	@include mq(large2) {
+		grid-auto-flow: column;
+		grid-auto-columns: 1fr;
+	}
 
-    &.center-column-pair {
-        grid-auto-flow: column;
-        grid-auto-columns: 1fr;
+	&.center-column-pair {
+		grid-auto-flow: column;
+		grid-auto-columns: 1fr;
 
-        // For mobile, the pair of columns will be stacked
-        .column-1 {
-            grid-row: 1 / 2;
-            grid-column: 1 / 2;
-        }
+		// For mobile, the pair of columns will be stacked
+		.column-1 {
+			grid-row: 1 / 2;
+			grid-column: 1 / 2;
+		}
 
-        .column-2 {
-            grid-row: 2 / 3;
-            grid-column: 1 / 2;
-        }
+		.column-2 {
+			grid-row: 2 / 3;
+			grid-column: 1 / 2;
+		}
 
-        @include mq(medium) {
-            grid-template-columns: repeat(2, 1fr);
+		@include mq(medium) {
+			grid-template-columns: repeat(2, 1fr);
 
-            .column-1 {
-                grid-row: 1 / 2;
-                grid-column: 1 / 2;
-            }
+			.column-1 {
+				grid-row: 1 / 2;
+				grid-column: 1 / 2;
+			}
 
-            .column-2 {
-                grid-row: 1 / 2;
-                grid-column: 2 / 3;
-            }
-        }
+			.column-2 {
+				grid-row: 1 / 2;
+				grid-column: 2 / 3;
+			}
+		}
 
-        @include mq(large) {
-            grid-template-columns: repeat(4, 1fr);
+		@include mq(large) {
+			grid-template-columns: repeat(4, 1fr);
 
-            .column-1 {
-                grid-row: 1 / 2;
-                grid-column: 2 / 3;
-            }
+			.column-1 {
+				grid-row: 1 / 2;
+				grid-column: 2 / 3;
+			}
 
-            .column-2 {
-                grid-row: 1 / 2;
-                grid-column: 3 / 4;
-            }
-        }
-    }
+			.column-2 {
+				grid-row: 1 / 2;
+				grid-column: 3 / 4;
+			}
+		}
+	}
 
-    &.textbox-card-pair {
-        grid-auto-flow: column;
-        grid-auto-columns: 1fr;
+	&.textbox-card-pair {
+		grid-auto-flow: column;
+		grid-auto-columns: 1fr;
 
-        // For mobile, the pair of columns will be stacked
-        .textbox-column {
-            grid-row: 1 / 2;
-            grid-column: 1 / 2;
-        }
+		// For mobile, the pair of columns will be stacked
+		.textbox-column {
+			grid-row: 1 / 2;
+			grid-column: 1 / 2;
+		}
 
-        .card-column {
-            grid-row: 2 / 3;
-            grid-column: 1 / 2;
-        }
+		.card-column {
+			grid-row: 2 / 3;
+			grid-column: 1 / 2;
+		}
 
-        // tablet
-        // Using medium2 breakpoint to have 
-        // two equal columns for ipad mini
-        @include mq(medium2) {
-            grid-template-columns: repeat(2, 1fr);
+		// tablet
+		// Using medium2 breakpoint to have
+		// two equal columns for ipad mini
+		@include mq(medium2) {
+			grid-template-columns: repeat(2, 1fr);
 
-            // textbox will be first column
-            .textbox-column {
-                grid-row: 1 / 2;
-                grid-column: 1 / 2;
-            }
+			// textbox will be first column
+			.textbox-column {
+				grid-row: 1 / 2;
+				grid-column: 1 / 2;
+			}
 
-            .card-column {
-                grid-row: 1 / 2;
-                grid-column: 2 / 3;
-            }
-        }
+			.card-column {
+				grid-row: 1 / 2;
+				grid-column: 2 / 3;
+			}
+		}
 
-        // desktop (large screens)
-        @include mq(large) {
-            grid-template-columns: repeat(3, 1fr);
+		// desktop (large screens)
+		@include mq(large) {
+			grid-template-columns: repeat(3, 1fr);
 
-            // textbox will be 1st and 2nd columns
-            .textbox-column {
-                grid-row: 1 / 2;
-                grid-column: 1 / 3;
-            }
+			// textbox will be 1st and 2nd columns
+			.textbox-column {
+				grid-row: 1 / 2;
+				grid-column: 1 / 3;
+			}
 
-            // card column will be 3rd column
-            .card-column {
-                grid-row: 1 / 2;
-                grid-column: 3 / 4;
-            }
-        }
-    }
+			// card column will be 3rd column
+			.card-column {
+				grid-row: 1 / 2;
+				grid-column: 3 / 4;
+			}
+		}
+	}
 
-    // case: multiple buttons in a row
-    // make width of all buttons equal
-    .button {
-        // TODO: need to take larger value of fit-content and 75% of width
-        width: 75%;
-    }
+	// case: multiple buttons in a row
+	// make width of all buttons equal
+	.button {
+		// TODO: need to take larger value of fit-content and 75% of width
+		width: 75%;
+	}
 }
-
 
 .even-columns {
-    @extend .grid;
-    grid-template-columns: 100%;
-    grid-template-areas:
-        "leftcol"
-        "rightcol";
+	@extend .grid;
+	grid-template-columns: 100%;
+	grid-template-areas:
+		'leftcol'
+		'rightcol';
 
-    @include mq(medium) {
-        grid-template-columns: 1fr 1fr;
-        grid-template-areas:
-            "leftcol rightcol";
-    }
+	@include mq(medium) {
+		grid-template-columns: 1fr 1fr;
+		grid-template-areas: 'leftcol rightcol';
+	}
 
-    &.reverse-mob {
+	&.reverse-mob {
+		// mobile
+		@include mqmax(medium) {
+			grid-template-columns: 100%;
+			grid-template-areas:
+				'rightcol'
+				'leftcol';
+		}
+	}
 
-        // mobile
-        @include mqmax(medium) {
-            grid-template-columns: 100%;
-            grid-template-areas:
-                "rightcol"
-                "leftcol";
-        }
-    }
+	&.reverse-tab {
+		// tablet
+		@include mqmax(large) {
+			grid-template-columns: 100%;
+			grid-template-areas:
+				'rightcol'
+				'leftcol';
+		}
+	}
 
-    &.reverse-tab {
+	&.hide-right-mob {
+		// mobile
+		@include mqmax(medium) {
+			.right-column {
+				display: none;
+			}
+		}
+	}
 
-        // tablet
-        @include mqmax(large) {
-            grid-template-columns: 100%;
-            grid-template-areas:
-                "rightcol"
-                "leftcol";
-        }
-    }
-
-    &.hide-right-mob {
-
-        // mobile
-        @include mqmax(medium) {
-            .right-column {
-                display: none;
-            }
-        }
-    }
-
-    &.hide-left-mob {
-
-        // mobile
-        @include mqmax(medium) {
-            .left-column {
-                display: none;
-            }
-        }
-    }
+	&.hide-left-mob {
+		// mobile
+		@include mqmax(medium) {
+			.left-column {
+				display: none;
+			}
+		}
+	}
 }
 
-
 .uneven-columns {
-    @extend .grid;
+	@extend .grid;
 
-    // narrow | wide columns
-    &.narrow-wide {
-        grid-template-columns: 100%;
-        grid-template-areas:
-            "narrowcol"
-            "widecol";
+	// narrow | wide columns
+	&.narrow-wide {
+		grid-template-columns: 100%;
+		grid-template-areas:
+			'narrowcol'
+			'widecol';
 
-        @include mq(medium) {
-            grid-template-columns: 34% 63%;
-            grid-template-areas:
-                "narrowcol widecol";
-        }
-    }
+		@include mq(medium) {
+			grid-template-columns: 34% 63%;
+			grid-template-areas: 'narrowcol widecol';
+		}
+	}
 
-    // narrow | wide columns with pullquote in narrow
-    &.pullquote-column {
-        grid-template-columns: 100%;
-        grid-template-areas:
-            "narrowcol"
-            "widecol";
+	// narrow | wide columns with pullquote in narrow
+	&.pullquote-column {
+		grid-template-columns: 100%;
+		grid-template-areas:
+			'narrowcol'
+			'widecol';
 
-        @include mq(medium) {
-            grid-template-columns: 24% 67% 6%;
-            grid-template-areas:
-                "narrowcol widecol spacercol";
-        }
+		@include mq(medium) {
+			grid-template-columns: 24% 67% 6%;
+			grid-template-areas: 'narrowcol widecol spacercol';
+		}
 
-        @include mq(medium) {
-            .image-plus {
-                width: 85% !important;
-                margin-left: auto !important;
-                margin-right: 0 !important;
-            }
-        }
+		@include mq(medium) {
+			.image-plus {
+				width: 85% !important;
+				margin-left: auto !important;
+				margin-right: 0 !important;
+			}
+		}
 
-        @include mq(large) {
-            .image-plus {
-                width: 95% !important;
-                margin-left: auto !important;
-                margin-right: 0 !important;
-            }
-        }
+		@include mq(large) {
+			.image-plus {
+				width: 95% !important;
+				margin-left: auto !important;
+				margin-right: 0 !important;
+			}
+		}
 
-        &.reverse-mob {
+		&.reverse-mob {
+			// mobile
+			@include mqmax(medium) {
+				grid-template-areas:
+					'widecol'
+					'narrowcol';
+			}
+		}
+	}
 
-            // mobile
-            @include mqmax(medium) {
-                grid-template-areas:
-                    "widecol"
-                    "narrowcol";
-            }
-        }
-    }
+	&.narrow-wide-40-60 {
+		grid-template-columns: 100%;
+		grid-template-areas:
+			'narrowcol'
+			'widecol';
 
-    &.narrow-wide-40-60 {
-        grid-template-columns: 100%;
-        grid-template-areas:
-            "narrowcol"
-            "widecol";
+		@include mq(medium) {
+			// auto takes care of wide-grid-gap and does not overflow from the grid
+			grid-template-columns: 40% auto;
+			grid-template-areas: 'narrowcol widecol';
+		}
+	}
 
-        @include mq(medium) {
-            // auto takes care of wide-grid-gap and does not overflow from the grid
-            grid-template-columns: 40% auto;
-            grid-template-areas:
-                "narrowcol widecol";
-        }
-    }
+	&.narrow-wide,
+	&.narrow-wide-40-60 {
+		&.reverse-mob {
+			// mobile
+			@include mqmax(medium) {
+				grid-template-areas:
+					'widecol'
+					'narrowcol';
+			}
+		}
 
-    &.narrow-wide,
-    &.narrow-wide-40-60 {
-        &.reverse-mob {
+		&.reverse-tab {
+			// tablet
+			@include mqmax(large) {
+				grid-template-areas:
+					'widecol'
+					'narrowcol';
+			}
+		}
+	}
 
-            // mobile
-            @include mqmax(medium) {
-                grid-template-areas:
-                    "widecol"
-                    "narrowcol";
-            }
-        }
+	// wide | narrow columns
+	&.wide-narrow {
+		grid-auto-columns: 100%;
+		grid-template-areas:
+			'widecol'
+			'narrowcol';
 
-        &.reverse-tab {
+		@include mq(medium) {
+			grid-template-columns: 63% 34%;
+			grid-template-areas: 'widecol narrowcol';
+		}
 
-            // tablet
-            @include mqmax(large) {
-                grid-template-areas:
-                    "widecol"
-                    "narrowcol";
-            }
-        }
-    }
+		&.reverse-mob {
+			// mobile
+			@include mqmax(medium) {
+				grid-template-areas:
+					'narrowcol'
+					'widecol';
+			}
+		}
 
-    // wide | narrow columns
-    &.wide-narrow {
-        grid-auto-columns: 100%;
-        grid-template-areas:
-            "widecol"
-            "narrowcol";
+		&.reverse-tab {
+			// tablet
+			@include mqmax(large) {
+				grid-template-areas:
+					'narrowcol'
+					'widecol';
+			}
+		}
+	}
 
-        @include mq(medium) {
-            grid-template-columns: 63% 34%;
-            grid-template-areas:
-                "widecol narrowcol";
-        }
+	&.wide-narrow-60-40 {
+		grid-template-columns: 100%;
+		grid-template-areas:
+			'widecol'
+			'narrowcol';
 
-        &.reverse-mob {
+		@include mq(medium) {
+			grid-template-columns: 60% auto;
+			grid-template-areas: 'widecol narrowcol';
+		}
+	}
 
-            // mobile
-            @include mqmax(medium) {
-                grid-template-areas:
-                    "narrowcol"
-                    "widecol";
-            }
-        }
+	&.wide-narrow,
+	&.wide-narrow-60-40 {
+		&.reverse-mob {
+			// mobile
+			@include mqmax(medium) {
+				grid-template-areas:
+					'narrowcol'
+					'widecol';
+			}
+		}
 
-        &.reverse-tab {
-
-            // tablet
-            @include mqmax(large) {
-                grid-template-areas:
-                    "narrowcol"
-                    "widecol";
-            }
-        }
-    }
-
-    &.wide-narrow-60-40 {
-        grid-template-columns: 100%;
-        grid-template-areas:
-            "widecol"
-            "narrowcol";
-
-        @include mq(medium) {
-            grid-template-columns: auto 40%;
-            grid-template-areas:
-                "widecol narrowcol";
-        }
-    }
-
-    &.wide-narrow,
-    &.wide-narrow-60-40 {
-        &.reverse-mob {
-
-            // mobile
-            @include mqmax(medium) {
-                grid-template-areas:
-                    "narrowcol"
-                    "widecol";
-            }
-        }
-
-        &.reverse-tab {
-
-            // tablet
-            @include mqmax(large) {
-                grid-template-areas:
-                    "narrowcol"
-                    "widecol";
-            }
-        }
-    }
+		&.reverse-tab {
+			// tablet
+			@include mqmax(large) {
+				grid-template-areas:
+					'narrowcol'
+					'widecol';
+			}
+		}
+	}
 }
 
 // all direct children in this column are stacked one above the other
 .stacked-column {
-    display: grid;
-    grid-template-columns: 1fr;
+	display: grid;
+	grid-template-columns: 1fr;
 
-    >* {
-        grid-row-start: 1;
-        grid-column-start: 1;
-    }
+	> * {
+		grid-row-start: 1;
+		grid-column-start: 1;
+	}
 }
 
 .left-align-column {
-    text-align: left;
+	text-align: left;
 
-    @include mqmax(medium) {
-        // align-self: center;
-        // margin: 0 auto;
-        text-align: left;
-    }
+	@include mqmax(medium) {
+		// align-self: center;
+		// margin: 0 auto;
+		text-align: left;
+	}
 }
 
 .right-align-column {
-    text-align: right;
+	text-align: right;
 
-    @include mqmax(medium) {
-        // align-self: center;
-        // margin: 0 auto;
-        text-align: left;
-    }
+	@include mqmax(medium) {
+		// align-self: center;
+		// margin: 0 auto;
+		text-align: left;
+	}
 }
 
 .bottom-align-column {
-    align-self: end;
+	align-self: end;
 }
 
 .top-align-column {
-    align-self: start;
+	align-self: start;
 }
 
 .center-align-column {
-    align-self: center;
+	align-self: center;
 }

--- a/netlify/functions/preview/src/sitemap.xml.njk
+++ b/netlify/functions/preview/src/sitemap.xml.njk
@@ -5,6 +5,7 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
     {%- for page in collections.all %}
+        {%- if not page.data.archive %}
         {% set absoluteUrl %}{{ page.url | htmlBaseUrl(metadata.url) }}{% endset %}
         <url>
             <loc>{{ absoluteUrl }}</loc>
@@ -12,5 +13,6 @@ eleventyExcludeFromCollections: true
             <changefreq>{{ page.data.sitemapChangefreq | default("monthly") }}</changefreq>
             <priority>{{ page.data.sitemapPriority | default(0.8) }}</priority>
         </url>
+        {%- endif %}
     {%- endfor %}
 </urlset>

--- a/netlify/functions/preview/src/summer-fun-for-kids.njk
+++ b/netlify/functions/preview/src/summer-fun-for-kids.njk
@@ -33,7 +33,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
   <div class="wrapper flow">
     <h3 class="center">Live. Move. Discover.</h3>
     <p>
-			A short drive from the bustle of Bangalore lies <b>Nrityagram Dance Village</b>, home to a community of dancers devoted to the pursuit of their art. The Nrityagram Dance Ensemble has performed across the world, earning international acclaim and numerous awards.
+			A short drive from the bustle of Bangalore lies <b>Nrityagram</b>, home to a community of dancers devoted to the pursuit of their art. The Nrityagram Dance Ensemble has performed across the world, earning international acclaim and numerous awards.
     </p>
     <p>
       <em>“The only proper response to dancers this amazing is worship.”</em>
@@ -56,7 +56,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       Dance and theatre have always been the core elements of the camp. This year, we are excited to introduce a new addition: <b>Aerial Silks</b>. In these sessions, participants explore movement on suspended silks, discovering the joy of moving through the air while developing strength, balance, coordination, and confidence.
     </p>
     <p>
-      The camp will be led by a team of experienced artists and educators. <b>Nivedita Paul</b>, a Nrityagram dancer and educator, will guide the Odissi dance sessions. <b>Nandakishore K.R.</b>, a theatre practitioner and long-time collaborator of Nrityagram, will lead movement and theatre classes. <b>Shruti Jasani</b>, performer and founder of The Wooden Stage in Mumbai, will lead sessions in Aerial Silks and Body Conditioning. 
+      The camp will be led by a team of experienced artistes and educators. <b>Nivedita Paul</b>, a Nrityagram dancer and educator, will guide the Odissi dance sessions. <b>Nandakishore K.R.</b>, a theatre practitioner and long-time collaborator of Nrityagram, will lead movement and theatre classes. <b>Shruti Jasani</b>, Nrityagram student and founder of The Wooden Stage in Mumbai, will lead sessions in Aerial Silks and Body Conditioning. 
     </p>
     <p>
       Throughout the camp, participants will live together on the Nrityagram campus, sharing the rhythms of village life while learning, creating, and <b>discovering new possibilities through movement, creativity, and imagination</b>. 
@@ -97,7 +97,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
     <span>
       <h1 class="center">Meet the Camp Mentors</h1>
       <p class="center">
-        <em>Artists and educators guiding creativity, movement, and discovery.</em>
+        <em>Artistes and educators guiding creativity, movement, and discovery.</em>
       </p>
     </span>
     <p>
@@ -116,7 +116,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Nivedita Paul</h2>
         <p>Nivedita Paul is an educator and researcher committed to children’s wellbeing, learning, and creative development. She is the founder of <a href="https://p3m.ai" target="_blank" class="bodylink">Pen Pencil Paper and More</a> , an EdTech and empowerment initiative, and has held several leadership and teaching roles in education, including Founding Principal at Ramakrishna Mission School in Kozhikode, Homeroom Tutor at the Aga Khan Academy in Hyderabad, and Teach for India Fellow in Mumbai.</p>
         <p>
-          Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of <a href="/pavithra" class="bodylink">Pavithra Reddy</a>, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
+          Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies through online classes with <a href="/surupa" class="bodylink">Surupa Sen</a> and since 2022,  as a Day Scholar under the guidance of <a href="/pavithra" class="bodylink">Pavithra Reddy</a>.
         </p>
         <p>
           She teaches the youngest students in Nrityagram’s outreach programme, bringing together her experience as an educator and her love for dance to introduce children to the beauty and joy of Odissi.
@@ -129,7 +129,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Nandakishore K.R.</h2>
         <p>Nandakishore K.R. is a theatre practitioner, lighting designer, mime artist, and movement designer with over three decades of experience in Indian theatre. He has collaborated with many of the country’s most distinguished theatre directors, including B.V. Karanth, Ebrahim Alkazi, Bansi Kaul, Ramgopal Bajaj, C. Basavalingaiah, V. Ramamurthy, and Habib Tanvir.</p>
         <p>
-          An active member of the Kannada amateur theatre movement, he has also worked with artists such as Shankar Nag, Prema Karanth, B. Jayashree, and Suresh Anagalli. His work spans lighting design, directing children’s theatre, visual art collaborations, and film and television, where he has worked as a director, art director, scriptwriter, and producer.
+          An active member of the Kannada amateur theatre movement, he has also worked with artistes such as Shankar Nag, Prema Karanth, B. Jayashree, and Suresh Anagalli. His work spans lighting design, directing children’s theatre, visual art collaborations, and film and television, where he has worked as a director, art director, scriptwriter, and producer.
         </p>
         <p>
           Associated with Nrityagram since its inception, Nandakishore brings his rich experience in theatre, movement, and storytelling to creative work with young performers.
@@ -155,7 +155,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       <div class="wide-column flow-inbetween">
         <h2>Shruti Jasani</h2>
         <p>Shruti Jasani is a performer and movement teacher whose work spans contemporary dance, ballet, theatre, and aerial arts. She studied contemporary dance and ballet at New York University and has been affiliated with Trinity College London since 2005, where she specialised in the Performing Arts syllabus, completing professional examinations and teaching dance and drama.</p>
-        <p>She has also trained at Aerial Arts New York and with Womack and Bowman, and is the co-founder of The Wooden Stage, a studio where she teaches aerial arts to both children and adults. In addition to teaching, Shruti has performed widely in theatre and public events, including appearances at TEDx and TiEcon, and currently plays Kaa the python in the musical production The Jungle Book – Part 2.</p>
+        <p>She has also trained at Aerial Arts New York and with Womack and Bowman, and is the co-founder of <a href="https://thewoodenstage.com/" target="_blank" class="bodylink">The Wooden Stage</a>, a studio where she teaches aerial arts to both children and adults. In addition to teaching, Shruti has performed widely in theatre and public events, including appearances at TEDx and TiEcon, and currently plays Kaa the python in the musical production The Jungle Book – Part 2.</p>
         <p>At the Summer Camp, Shruti will lead sessions in Aerial Silk Movement and Body Conditioning, inviting young participants to experience strength, balance, and imagination in motion.</p>
       </div>
     </div>
@@ -258,7 +258,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       <div class="credit" data-image-credit="Rupert Lorhaldar" ></div>
     </div>
     <p>
-      Located a short distance from Bangalore, <b>Nrityagram Dance Village</b> is a unique community dedicated to the pursuit of classical dance.
+      Located a short distance from Bangalore, <b>Nrityagram</b> is a unique community dedicated to the pursuit of Odissi dance.
     </p>
     <p>
       During the camp, participants live together on the campus, surrounded by flowering trees, birds, and open spaces. In this environment - free from screens and everyday distractions - children experience a mindful way of living where creativity, discipline, and community go hand in hand.
@@ -267,7 +267,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       The participants will stay in our artistes residence, Kula, which has 8 rooms (2-3 beds per room) with ensuite bathrooms, a common kitchenette (for refreshments and snacks) and a courtyard.
     </p>
     <p>
-      All the teachers and students of Nrityagram stay within the campus in houses and rooms near Kula and camp participants will be supervised by an adult at all times. All meals and refreshments will be in the common dining area and are primarily vegetarian.
+      All the teachers and students of Nrityagram live within the campus in houses and rooms near Kula and camp participants will be supervised by an adult at all times. All meals and refreshments will be in the common dining area and are primarily vegetarian.
     </p>
   </div>
 </div>
@@ -284,7 +284,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       <li>
         <b>Unique Creative Environment</b>
         <br>
-        Children spend their days immersed in dance, theatre, and movement within the inspiring surroundings of Nrityagram Dance Village.
+        Children spend their days immersed in dance, theatre, and movement within the inspiring surroundings of Nrityagram.
       </li>
       <li>&nbsp;</li>
       <li>
@@ -334,24 +334,16 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <b>Age</b>: 7 - 12 years
       </li>
       <li>
-        <ul class="no-bullets">
-          <li>
-            <b>Location</b>: Nrityagram
-          </li>
-          <li>
-            <b>Residential</b>: Yes
-          </li>
-        </ul>
+        <b>Location</b>: Nrityagram
       </li>
       <li>
-        <ul class="no-bullets">
-          <li>
-            <b>Number of Participants</b>: Limited places available
-          </li>
-          <li>
-            <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
-          </li>
-        </ul>
+        <b>Residential</b>: Yes
+      </li>
+      <li>
+        <b>Number of Participants</b>: Limited places available
+      </li>
+      <li>
+        <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
       </li>
       <li>
         <b>Enrolment & Payment Terms</b>

--- a/netlify/functions/preview/src/summer-fun-for-kids.njk
+++ b/netlify/functions/preview/src/summer-fun-for-kids.njk
@@ -31,33 +31,41 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
 </div>
 <div class="container">
   <div class="wrapper flow">
+    <h3 class="center">Live. Move. Discover.</h3>
     <p>
-			Far from the bustle of Bangalore lies <b>Nrityagram Dance Village</b>, home to a community of dancers who have devoted their lives to the pursuit of their art. The Nrityagram Dance Ensemble has performed across the world, earning international acclaim. As <em>The New York Times said, “The only proper response to dancers this amazing is worship!”</em>
+			A short drive from the bustle of Bangalore lies <b>Nrityagram Dance Village</b>, home to a community of dancers devoted to the pursuit of their art. The Nrityagram Dance Ensemble has performed across the world, earning international acclaim and numerous awards.
     </p>
-    <p>But what is daily life like in this remarkable place?</p>
+    <p>
+      <em>“The only proper response to dancers this amazing is worship.”</em>
+      <br />
+      <b>The New York Times</b>
+    </p>
+    <p>
+      But what is daily life like in this remarkable place?
+    </p>
     <p>
       Every year, a small group of children get the opportunity to find out by enrolling in <b>Nrityagram’s Summer Fun for Kids</b>. For a few special days, they experience life at Nrityagram through dance, theatre, storytelling, games, nature walks, and shared community activities.
     </p>
     <p>
-      <b>Summer Fun for Kids</b> is a unique short-term residential camp that offers participants a glimpse into the Nrityagram philosophy - where learning is not confined to a classroom, but lived as a way of life. Away from television screens and video games, and surrounded by flowering trees, birds, and open spaces, children experience a rhythm of living where everyone cares for themselves, their surroundings, and their shared home.
+      <b>Summer Fun for Kids</b> is a unique short-term residential camp that offers participants a glimpse into the Nrityagram philosophy - where learning is not confined to a classroom, but lived as a way of life. Away from television screens and video games, and surrounded by flowering trees, birds, and open spaces, children experience a rhythm of living where everyone learns to care for themselves, their surroundings, and their shared home.
     </p>
     <p>
       The camp also introduces children to the spirit of the <b>guru-shishya parampara</b> that guides learning at Nrityagram. Participants follow a five-hour daily learning schedule that includes dance and theatre sessions, along with yoga, body conditioning, and creative art activities. They also take part in simple everyday tasks such as cooking, gardening, and caring for the campus - becoming part of the community for the duration of the camp. Many children (and their parents) later describe the experience as truly life-changing.
     </p>
     <p>
-      Dance and theatre have always been the core elements of the camp. This year, we are excited to introduce a new addition: <b>Aerial Silk Work</b>.
+      Dance and theatre have always been the core elements of the camp. This year, we are excited to introduce a new addition: <b>Aerial Silks</b>. In these sessions, participants explore movement on suspended silks, discovering the joy of moving through the air while developing strength, balance, coordination, and confidence.
     </p>
     <p>
-      The camp will be led by a team of experienced artists and educators. <b>Nivedita Paul</b>, a Nrityagram dancer and educator, will guide the Odissi dance sessions. <b>Nandakishore K.R.</b>, a theatre practitioner and long-time collaborator of Nrityagram, will lead movement and theatre classes. <b>Shruti Jasani</b>, performer and founder of The Wooden Stage in Mumbai, will conduct sessions in Aerial Silk Movement and Body Conditioning.
+      The camp will be led by a team of experienced artists and educators. <b>Nivedita Paul</b>, a Nrityagram dancer and educator, will guide the Odissi dance sessions. <b>Nandakishore K.R.</b>, a theatre practitioner and long-time collaborator of Nrityagram, will lead movement and theatre classes. <b>Shruti Jasani</b>, performer and founder of The Wooden Stage in Mumbai, will lead sessions in Aerial Silks and Body Conditioning. 
     </p>
     <p>
-      Throughout the camp, participants will live together on the Nrityagram campus, sharing the rhythms of village life while learning, creating, and discovering new possibilities through movement and imagination.
+      Throughout the camp, participants will live together on the Nrityagram campus, sharing the rhythms of village life while learning, creating, and <b>discovering new possibilities through movement, creativity, and imagination</b>. 
     </p>
   </div>
 </div>
 <div class="container accent-bg">
   <div class="wrapper flow">
-    <h1 class="center">Nrityagram Arts in Education Program</h1>
+    <h1 class="center">Nrityagram Arts in Education Programme</h1>
     <div class="image-plus top-flow">
       {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739366286/arts-in-education_dsd40i.png",
       "Children at the Summer Fun for Kids performing at the Odissi gurukul",
@@ -65,13 +73,21 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       <div class="credit" data-image-credit="Courtesy Nrityagram" ></div>
     </div>
     <p>
-			Nrityagram’s Outreach Programme on Sundays, started in 1990 by founder <a href="/protima" class="bodylink">Protima Gauri</a>, is a part of Project Nrityagyān (Dance Education) with a broadened vision to also promote personal growth by developing a strong sense of discipline, high standards of excellence and self-esteem, thus providing children tools to a successful future. 
+      <em>
+        Rooted in the Nrityagram philosophy of learning as a way of life, this programme introduces children to classical dance while nurturing creativity, discipline, and self-confidence.
+      </em>
+    </p>
+    <p>
+			Nrityagram’s <b>Outreach Programme</b>, held every Sunday, was initiated in 1990 by founder <a href="/protima" class="bodylink">Protima Gauri</a> as part of <em>Project Nrityagyān</em> (Dance Education). The programme was envisioned not only as a way to introduce children to classical dance, but also as a means of nurturing personal growth - cultivating discipline, self-confidence, creativity, and a commitment to excellence. 
 		</p>
     <p>
-			Nrityagram’s dancers have developed a method of teaching that is educational, exciting, fun and at the same time uncompromising on excellence and the high standards required to learn classical dance. Our classes are full of energy, passion, commitment, honesty and respect from both sides - teacher and students. This method has helped us to almost instantly win a child's trust because they immediately feel SAFE in class. Children receive honest feedback while knowing that each of them is special, that there are small achievements every day and that they will succeed. And they enthusiastically accept feedback and wholeheartedly put their efforts into new challenges. 
+			Over the years, Nrityagram’s dancers have developed a teaching approach that is rigorous yet joyful. Classes are energetic, engaging, and grounded in the high standards required to learn classical dance. At the same time, they are designed to create an environment where children feel supported, encouraged, and inspired to grow. 
 		</p>
     <p>
-      Our summer camp aspires to heighten this experience for participants by being residential and intensive, as well as multidisciplinary. The simple goals that are the prime focus of this camp are building self-confidence, fostering team spirit, self and group motivation, kindling creative imagination, physical coordination, awareness of rhythms and a sense of music, and nurturing uninhibited expression.
+      A spirit of trust lies at the heart of this approach. Students receive honest feedback while learning to value their own progress, celebrate small achievements, and work steadily toward new challenges. The classroom becomes a space of respect and collaboration, where teachers and students share a commitment to learning.
+    </p>
+    <p>
+      <b>Nrityagram’s Summer Fun for Kids</b> builds on this philosophy. As a residential and multidisciplinary camp, it deepens the experience by immersing participants in a creative community. Through dance, theatre, movement, and shared daily activities, the camp encourages self-confidence, teamwork, imagination, physical coordination, musical awareness, and free, joyful expression.
     </p>
 
   </div>
@@ -80,11 +96,13 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
   <div class="wrapper flow flow-extra">
     <span>
       <h1 class="center">Meet the Camp Mentors</h1>
-      <h4 class="center">Artists and educators guiding creativity, movement, and discovery.</h4>
+      <p class="center">
+        <em>Artists and educators guiding creativity, movement, and discovery.</em>
+      </p>
     </span>
     <p>
-            This year’s Summer Camp is led by a team of experienced educators and performers from the worlds of dance, theatre, and movement, who bring creativity, discipline, and joyful exploration to young learners.
-        </p>
+      This year’s Summer Camp is led by a team of experienced educators and performers from the worlds of dance, theatre, and movement, who bring creativity, discipline, and joyful exploration to young learners.
+    </p>
 
     <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
       <div class="narrow-column">
@@ -98,11 +116,11 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Nivedita Paul</h2>
         <p>Nivedita Paul is an educator and researcher committed to children’s wellbeing, learning, and creative development. She is the founder of <a href="https://p3m.ai" target="_blank" class="bodylink">Pen Pencil Paper and More</a> , an EdTech and empowerment initiative, and has held several leadership and teaching roles in education, including Founding Principal at Ramakrishna Mission School in Kozhikode, Homeroom Tutor at the Aga Khan Academy in Hyderabad, and Teach for India Fellow in Mumbai.</p>
         <p>
-              Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of <a href="/pavithra" class="bodylink">Pavithra Reddy</a>, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
-            </p>
+          Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of <a href="/pavithra" class="bodylink">Pavithra Reddy</a>, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
+        </p>
         <p>
-              She teaches the youngest students in Nrityagram’s outreach programme, bringing together her experience as an educator and her love for dance to introduce children to the beauty and joy of Odissi.
-            </p>
+          She teaches the youngest students in Nrityagram’s outreach programme, bringing together her experience as an educator and her love for dance to introduce children to the beauty and joy of Odissi.
+        </p>
       </div>
     </div>
 
@@ -111,11 +129,11 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Nandakishore K.R.</h2>
         <p>Nandakishore K.R. is a theatre practitioner, lighting designer, mime artist, and movement designer with over three decades of experience in Indian theatre. He has collaborated with many of the country’s most distinguished theatre directors, including B.V. Karanth, Ebrahim Alkazi, Bansi Kaul, Ramgopal Bajaj, C. Basavalingaiah, V. Ramamurthy, and Habib Tanvir.</p>
         <p>
-              An active member of the Kannada amateur theatre movement, he has also worked with artists such as Shankar Nag, Prema Karanth, B. Jayashree, and Suresh Anagalli. His work spans lighting design, directing children’s theatre, visual art collaborations, and film and television, where he has worked as a director, art director, scriptwriter, and producer.
-            </p>
+          An active member of the Kannada amateur theatre movement, he has also worked with artists such as Shankar Nag, Prema Karanth, B. Jayashree, and Suresh Anagalli. His work spans lighting design, directing children’s theatre, visual art collaborations, and film and television, where he has worked as a director, art director, scriptwriter, and producer.
+        </p>
         <p>
-              Associated with Nrityagram since its inception, Nandakishore brings his rich experience in theatre, movement, and storytelling to creative work with young performers.
-            </p>
+          Associated with Nrityagram since its inception, Nandakishore brings his rich experience in theatre, movement, and storytelling to creative work with young performers.
+        </p>
       </div>
       <div class="narrow-column">
         <div class="image-plus">
@@ -167,45 +185,138 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
 </div>
 <div class="container accent-bg">
   <div class="wrapper flow">
-    <h1 class="center">About Kula: Artistes Residence</h1>
+    <h1 class="center">What Children Experience</h1>
     <div class="image-plus top-flow">
-      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
-      "Kula Artistes Residence",
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1773124890/summer-fun-for-kids-2025-3_iup5v6.jpg",
+      "Summer Fun for Kids participants enjoying a nature walk on the Nrityagram campus",
       ["560", "768", "1046"] %}
-      <div class="credit" data-image-credit="Rupert Lorhalder" ></div>
+      <div class="credit" data-image-credit="Courtesy of Nrityagram" ></div>
     </div>
     <p>
-      The participants will stay in our artistes residence - <a href="/kula-artistes-residence" class="bodylink">Kula</a>, which has 8 rooms (2-3 beds per room) with ensuite bathrooms, a common kitchenette (for refreshments and snacks) and a courtyard.
+      At Nrityagram, learning happens not only in the studio but throughout daily life. Participants experience a balance of creative exploration, physical activity, and shared community living.
     </p>
     <p>
-      All the teachers and students of Nrityagram stay within the campus in houses and rooms near Kula and camp participants will be supervised by an adult at all times. All meals and refreshments will be in the common dining area and are primarily vegetarian. 
+      The programme includes:
+      <ul>
+        <li>
+          <b>Odissi Dance</b>
+        </li>
+        <li>
+          <b>Movement and Theatre</b>
+        </li>
+        <li>
+          <b>Aerial Silks</b>
+        </li>
+        <li>
+          <b>Yoga and Body Conditioning</b>
+        </li>
+        <li>
+          <b>Art and Creative Activities</b>
+        </li>
+        <li>
+          <b>Nature Walks and Storytelling</b>
+        </li>
+        <li>
+          <b>Simple Community Activities</b> such as gardening and caring for shared spaces</li>
+      </ul>
     </p>
     <p>
-      In addition to engaging in dance and theatre workshops, camp participants will also be introduced to elements of organic gardening, bird watching and environmental awareness in what is today Bangalore’s only remaining grassland in Hessaraghatta.
+      Together, these experiences nurture creativity, confidence, teamwork, physical coordination, and joyful self-expression.
     </p>
   </div>
 </div>
 <div class="container">
   <div class="wrapper flow">
-    <h1 class="center">Important Notes</h1>
+    <h1 class="center">A Day at Camp</h1>
+    <div class="image-plus top-flow">
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1773126094/summer-fun-for-kids-2025-11_eggaqs.png",
+      "Summer Fun for Kids participants engaging in a creative activity on the Nrityagram campus",
+      ["560", "768", "1046"] %}
+      <div class="credit" data-image-credit="Courtesy of Nrityagram" ></div>
+    </div>
     <p>
-      Careful planning and supervision helps us to provide a safe environment for everyone. Parents must be aware however, that Nrityagram is a rural location and we spend a lot of time outdoors and children will be involved in physical activities including but not limited to their classrooms, climbing trees and outdoor play.
+      Each day at Nrityagram follows a gentle rhythm that balances learning, creativity, and play.
     </p>
     <p>
-      If you have questions or concerns, please email us your phone number and we will return your call. 
+      Participants spend around <b>five hours in guided sessions</b>, divided between dance, theatre, and aerial work, along with yoga and body conditioning. The rest of the day includes nature walks, creative activities, storytelling, and time to relax and enjoy the beauty of the Nrityagram campus.
     </p>
     <p>
-      Email: <a href="mailto:pavithra@nrityagram.org" class="bodylink">pavithra@nrityagram.org</a>
+      In addition to engaging in dance, theatre, and aerial silks, camp participants will also be introduced to bird watching and environmental awareness in what is today Bangalore’s only remaining grassland ecosystem at Hessaraghatta.
+    </p>
+    <p>
+      Children also participate in simple everyday activities such as gardening and caring for shared spaces, becoming part of the Nrityagram community during their stay.
     </p>
   </div>
 </div>
 <div class="container accent-bg">
   <div class="wrapper flow">
-    <h1 class="center">Details</h1>
-    <ul class="extra-margin-top no-bullets">
+    <h1 class="center">Life at Nrityagram</h1>
+    <div class="image-plus top-flow">
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1583857821/6-Kula_fldxvp.jpg",
+      "Kula - the artiste residential area at Nrityagram",
+      ["560", "768", "1046"] %}
+      <div class="credit" data-image-credit="Rupert Lorhaldar" ></div>
+    </div>
+    <p>
+      Located a short distance from Bangalore, <b>Nrityagram Dance Village</b> is a unique community dedicated to the pursuit of classical dance.
+    </p>
+    <p>
+      During the camp, participants live together on the campus, surrounded by flowering trees, birds, and open spaces. In this environment - free from screens and everyday distractions - children experience a mindful way of living where creativity, discipline, and community go hand in hand.
+    </p>
+    <p>
+      The participants will stay in our artistes residence, Kula, which has 8 rooms (2-3 beds per room) with ensuite bathrooms, a common kitchenette (for refreshments and snacks) and a courtyard.
+    </p>
+    <p>
+      All the teachers and students of Nrityagram stay within the campus in houses and rooms near Kula and camp participants will be supervised by an adult at all times. All meals and refreshments will be in the common dining area and are primarily vegetarian.
+    </p>
+  </div>
+</div>
+<div class="container">
+  <div class="wrapper flow">
+    <h1 class="center">Why Parents Love This Camp</h1>
+    <div class="image-plus top-flow">
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1773127241/summer-fun-for-kids-2025-13_jvryhy.png",
+      "Summer Fun for Kids participants enjoying a creative activity and the natural outdoors in the Nrityagram campus",
+      ["560", "768", "1046"] %}
+      <div class="credit" data-image-credit="Courtesy of Nrityagram" ></div>
+    </div>
+    <ul class="no-bullets">
       <li>
-        <b>Age</b>: 7 - 12 years
+        <b>Unique Creative Environment</b>
+        <br>
+        Children spend their days immersed in dance, theatre, and movement within the inspiring surroundings of Nrityagram Dance Village.
       </li>
+      <li>&nbsp;</li>
+      <li>
+        <b>Confidence and Self-Expression</b>
+        <br>
+         Through performance-based learning and creative exploration, children develop confidence, communication skills, and a sense of self.
+      </li>
+      <li>&nbsp;</li>
+      <li>
+        <b>Learning Through Community Living</b>
+        <br>
+        Living together on campus helps children experience cooperation, responsibility, and respect for shared spaces.
+      </li>
+      <li>&nbsp;</li>
+      <li>
+        <b>Connection with Nature</b>
+        <br>
+        Surrounded by trees, birds, and open spaces, participants spend time outdoors and reconnect with the rhythms of the natural world.
+      </li>
+      <li>&nbsp;</li>
+      <li>
+        <b>Joyful Discipline</b>
+        <br>
+        Children experience the balance of structure and play that lies at the heart of the Nrityagram philosophy of learning.
+      </li>
+    </ul>
+  </div>
+</div>
+<div class="container accent-bg">
+  <div class="wrapper flow">
+    <h1 class="center">Practical Details</h1>
+    <ul class="extra-margin-top no-bullets">
       <li>
         <ul class="no-bullets">
           <li>
@@ -220,13 +331,33 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         </ul>
       </li>
       <li>
-        <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
+        <b>Age</b>: 7 - 12 years
+      </li>
+      <li>
+        <ul class="no-bullets">
+          <li>
+            <b>Location</b>: Nrityagram
+          </li>
+          <li>
+            <b>Residential</b>: Yes
+          </li>
+        </ul>
+      </li>
+      <li>
+        <ul class="no-bullets">
+          <li>
+            <b>Number of Participants</b>: Limited places available
+          </li>
+          <li>
+            <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
+          </li>
+        </ul>
       </li>
       <li>
         <b>Enrolment & Payment Terms</b>
         <ul >
           <li>
-            We accept students on a first-come first-served basis, and due to the high level of interest and limited space, we suggest that you sign up immediately, in order to secure a place.
+            We accept students on a first-come first-served basis, and due to the high level of interest and limited space, we suggest that you sign up immediately to secure a place.
           </li>
           <li>
             The full tuition fee must be paid in advance to reserve a place in the Camp. This amount is non-refundable unless we cancel the Camp.
@@ -270,7 +401,12 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <b>Registration</b>: To complete registration, we will provide a link to the registration form that will need to be completed prior to the start of the Camp.
       </li>
       <li>
-        <b>Preparing for the Camp</b>: By mid-March, we will provide detailed information including guidelines, packing list, daily class schedule, etc.
+        <b>Preparing for the Camp</b>: By the second week of April, we will provide detailed information including guidelines, packing list, daily class schedule, etc.
+      </li>
+      <li>
+      If you have questions or concerns, please email us your phone number and we will return your call. 
+      <br />
+      Email: <a href="mailto:pavithra@nrityagram.org" class="bodylink">pavithra@nrityagram.org</a>
       </li>
       <li>
         <b>How to get to Nrityagram</b>: <a href="/findyourway" class="bodylink">Directions</a>

--- a/netlify/functions/preview/src/summer-fun-for-kids.njk
+++ b/netlify/functions/preview/src/summer-fun-for-kids.njk
@@ -98,7 +98,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Nivedita Paul</h2>
         <p>Nivedita Paul is an educator and researcher committed to children’s wellbeing, learning, and creative development. She is the founder of <a href="https://p3m.ai" target="_blank" class="bodylink">Pen Pencil Paper and More</a> , an EdTech and empowerment initiative, and has held several leadership and teaching roles in education, including Founding Principal at Ramakrishna Mission School in Kozhikode, Homeroom Tutor at the Aga Khan Academy in Hyderabad, and Teach for India Fellow in Mumbai.</p>
         <p>
-              Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of Pavithra Reddy, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
+              Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of <a href="/pavithra" class="bodylink">Pavithra Reddy</a>, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
             </p>
         <p>
               She teaches the youngest students in Nrityagram’s outreach programme, bringing together her experience as an educator and her love for dance to introduce children to the beauty and joy of Odissi.
@@ -106,7 +106,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       </div>
     </div>
 
-    <div class="uneven-columns wide-grid-gap wide-narrow-60-40">
+    <div class="uneven-columns wide-grid-gap wide-narrow-60-40 reverse-mob">
       <div class="wide-column flow-inbetween">
         <h2>Nandakishore K.R.</h2>
         <p>Nandakishore K.R. is a theatre practitioner, lighting designer, mime artist, and movement designer with over three decades of experience in Indian theatre. He has collaborated with many of the country’s most distinguished theatre directors, including B.V. Karanth, Ebrahim Alkazi, Bansi Kaul, Ramgopal Bajaj, C. Basavalingaiah, V. Ramamurthy, and Habib Tanvir.</p>

--- a/netlify/functions/preview/src/summer-fun-for-kids.njk
+++ b/netlify/functions/preview/src/summer-fun-for-kids.njk
@@ -176,10 +176,10 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
             <li>
                 <ul class="no-bullets">
                     <li>
-                        <b>Arrival Date</b>: 21 April 2025, 3 - 5pm
+                        <b>Arrival Date</b>: 13 April 2025, 3 - 5pm
           </li>
                     <li>
-                        <b>Departure Date</b>: 26 April 2025, 3 - 5pm
+                        <b>Departure Date</b>: 18 April 2025, 3 - 5pm
           </li>
                     <li>
             The start date is non-negotiable.

--- a/netlify/functions/preview/src/summer-fun-for-kids.njk
+++ b/netlify/functions/preview/src/summer-fun-for-kids.njk
@@ -11,238 +11,270 @@ description: "Nrityagram’s Summer Fun for Kids is a unique short-term resident
 OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-fun-OG_isgvbz.png"
 ---
 <div id="banner-container">
-    <div class="banner-image">
-        {% pictures 
+  <div class="banner-image">
+    {% pictures 
       {"desk":"https://res.cloudinary.com/nrityagram/image/upload/v1739344263/summer-fun-desk_ljiw54.png", 
       "tab":"https://res.cloudinary.com/nrityagram/image/upload/v1739344263/summer-fun-tablet_ytma9m.png", 
       "mob":"https://res.cloudinary.com/nrityagram/image/upload/v1739344263/summer-fun-mobile_f8o3wu.png"}, 
       "Summer Fun for Kids", 
       {"mob": ["425"], "tab": ["768"], "desk":["1600"]}, {"desk":"65em", "tab":"50em", "mob":"35em"}, 
       "eager", "high" %}
-    </div>
-    <div class="banner-image-credit"
+  </div>
+  <div class="banner-image-credit"
     data-image-credit-desk="Courtesy Nrityagram" 
     data-image-credit-tab="Courtesy Nrityagram" 
     data-image-credit-mob="Courtesy Nrityagram"
     ></div>
-    <div class="banner-title">
+  <div class="banner-title">
         Summer Fun<br />for Kids
   </div>
 </div>
 <div class="container">
-    <div class="wrapper flow">
-        <p>
-			Far from the bustle of Bangalore, the Nrityagram Dance Village houses a group of dancers who have excelled in pursuit of their art. They have performed across the world, won numerous awards and earned global acclaim. According to The New York Times “The only proper response to dancers this amazing is worship!”
-		</p>
-        <p>Who are these dancers, and what do they do all day at Nrityagram?</p>
-        <p>
-      Every year, a small group of children get an opportunity to enrol in Nrityagram’s Summer Fun for Kids to find out for themselves, by leading the Nrityagram life focused on dance and theatre. They explore spaces, go on nature walks, tell stories, play games and most importantly have lots of fun.
+  <div class="wrapper flow">
+    <p>
+			Far from the bustle of Bangalore lies <b>Nrityagram Dance Village</b>, home to a community of dancers who have devoted their lives to the pursuit of their art. The Nrityagram Dance Ensemble has performed across the world, earning international acclaim. As <em>The New York Times said, “The only proper response to dancers this amazing is worship!”</em>
     </p>
-        <p>
-      Nrityagram’s Summer Fun for Kids is a unique short-term residential camp, which brings to participants a compact experience of the Nrityagram philosophy of learning as a way of life.
+    <p>But what is daily life like in this remarkable place?</p>
+    <p>
+      Every year, a small group of children get the opportunity to find out by enrolling in <b>Nrityagram’s Summer Fun for Kids</b>. For a few special days, they experience life at Nrityagram through dance, theatre, storytelling, games, nature walks, and shared community activities.
     </p>
-        <p>
-      Far away from television sets and video games, surrounded by lush foliage, beautiful birds and flowering trees, they experience life in a place where all residents take care of themselves and their “home" and where the entire community lives mindfully. The camp also gives children a glimpse into the guru-shishya parampara followed at Nrityagram, while they are led through dance and theatre sessions.
+    <p>
+      <b>Summer Fun for Kids</b> is a unique short-term residential camp that offers participants a glimpse into the Nrityagram philosophy - where learning is not confined to a classroom, but lived as a way of life. Away from television screens and video games, and surrounded by flowering trees, birds, and open spaces, children experience a rhythm of living where everyone cares for themselves, their surroundings, and their shared home.
     </p>
-        <p>
-      Camp participants follow a five-hour daily learning schedule, with theatre and dance in two separate batches, in addition to engaging in and learning simple day-to-day activities such as cleaning, cooking and gardening. They also participate in yoga and body conditioning classes, in addition to fun sessions in art. Most of the children (and their parents) describe the experience as ‘life changing’.
+    <p>
+      The camp also introduces children to the spirit of the <b>guru-shishya parampara</b> that guides learning at Nrityagram. Participants follow a five-hour daily learning schedule that includes dance and theatre sessions, along with yoga, body conditioning, and creative art activities. They also take part in simple everyday tasks such as cooking, gardening, and caring for the campus - becoming part of the community for the duration of the camp. Many children (and their parents) later describe the experience as truly life-changing.
     </p>
-        <p>
-      The two basic components of the camp are dance and theatre. One of India’s best known Odissi Dancers <a href="/pavithra" class="bodylink">Pavithra Reddy</a>, a <a href="/ensemble" class="bodylink">Nrityagram Ensemble</a> and faculty member, will lead the sessions in Odissi dance.
+    <p>
+      Dance and theatre have always been the core elements of the camp. This year, we are excited to introduce a new addition: <b>Aerial Silk Work</b>.
     </p>
-        <p>
-      This year we have invited Shruti Jasani to teach theatre and Yoga classes. Shruti leads the faculty at The Wooden Stage, a performance arts institute in Mumbai teaching aerial art to over 400 students.
+    <p>
+      The camp will be led by a team of experienced artists and educators. <b>Nivedita Paul</b>, a Nrityagram dancer and educator, will guide the Odissi dance sessions. <b>Nandakishore K.R.</b>, a theatre practitioner and long-time collaborator of Nrityagram, will lead movement and theatre classes. <b>Shruti Jasani</b>, performer and founder of The Wooden Stage in Mumbai, will conduct sessions in Aerial Silk Movement and Body Conditioning.
     </p>
-        <p>
-      Everyone will live at the Nrityagram campus.
+    <p>
+      Throughout the camp, participants will live together on the Nrityagram campus, sharing the rhythms of village life while learning, creating, and discovering new possibilities through movement and imagination.
     </p>
-    </div>
+  </div>
 </div>
 <div class="container accent-bg">
-    <div class="wrapper flow">
-        <h1 class="center">Nrityagram Arts in Education Program</h1>
-        <div class="image-plus top-flow">
-            {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739366286/arts-in-education_dsd40i.png",
+  <div class="wrapper flow">
+    <h1 class="center">Nrityagram Arts in Education Program</h1>
+    <div class="image-plus top-flow">
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739366286/arts-in-education_dsd40i.png",
       "Children at the Summer Fun for Kids performing at the Odissi gurukul",
       ["560", "768", "1046"] %}
-            <div class="credit" data-image-credit="Courtesy Nrityagram" ></div>
-        </div>
-        <p>
+      <div class="credit" data-image-credit="Courtesy Nrityagram" ></div>
+    </div>
+    <p>
 			Nrityagram’s Outreach Programme on Sundays, started in 1990 by founder <a href="/protima" class="bodylink">Protima Gauri</a>, is a part of Project Nrityagyān (Dance Education) with a broadened vision to also promote personal growth by developing a strong sense of discipline, high standards of excellence and self-esteem, thus providing children tools to a successful future. 
 		</p>
-        <p>
+    <p>
 			Nrityagram’s dancers have developed a method of teaching that is educational, exciting, fun and at the same time uncompromising on excellence and the high standards required to learn classical dance. Our classes are full of energy, passion, commitment, honesty and respect from both sides - teacher and students. This method has helped us to almost instantly win a child's trust because they immediately feel SAFE in class. Children receive honest feedback while knowing that each of them is special, that there are small achievements every day and that they will succeed. And they enthusiastically accept feedback and wholeheartedly put their efforts into new challenges. 
 		</p>
-        <p>
+    <p>
       Our summer camp aspires to heighten this experience for participants by being residential and intensive, as well as multidisciplinary. The simple goals that are the prime focus of this camp are building self-confidence, fostering team spirit, self and group motivation, kindling creative imagination, physical coordination, awareness of rhythms and a sense of music, and nurturing uninhibited expression.
     </p>
 
-    </div>
+  </div>
 </div>
 <div class="container">
-    <div class="wrapper flow flow-extra">
-        <h1 class="center">The Teachers</h1>
-        <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
-            <div class="narrow-column">
-                <div class="image-plus">
-                    {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739366969/shruti_jasani_fadvlv.jpg",
-                    "Shruti Jasani",
-                    ["auto", "425"] %}
-                </div>
-            </div>
-            <div class="wide-column flow-inbetween">
-                <h2>Shruti Jasani</h2>
-                <p>
-          Shruti studied contemporary dance and ballet at The New York University, and has also been affiliated with the Trinity College of London since 2005 where she specialised in the Performance Arts syllabus, taking professional level exams and also teaching dance and drama under the same roof. She has also studied at Aerial Arts New York, and Womack and Bowman, This wealth of knowledge, while great on paper, really shines through when you experience an aerial class at The Wooden Stage, taught by Shruti.
+  <div class="wrapper flow flow-extra">
+    <span>
+      <h1 class="center">Meet the Camp Mentors</h1>
+      <h4 class="center">Artists and educators guiding creativity, movement, and discovery.</h4>
+    </span>
+    <p>
+            This year’s Summer Camp is led by a team of experienced educators and performers from the worlds of dance, theatre, and movement, who bring creativity, discipline, and joyful exploration to young learners.
         </p>
-                <p>
-          In addition to co-founding a successful studio (TWC) where she quite literally “hangs” with grown-up and child students who can’t wait for class o’ clock, Shruti has also taken her aerial skills to the silver screen.
-        </p>
-                <p>
-          Shruti has also been invited to showcase her skills at TedX, besides speaking and performing at Tiecon and doing theatre performances. She plays KAA the python in Jungle Book part 2 Musical.
-        </p>
-            </div>
 
-        </div>
-
-        <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
-            <div class="narrow-column">
-                <div class="image-plus">
-                    {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739369921/pavi-reddy-summer-fun_moh4q7.png",
-          "Pavithra Reddy",
+    <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
+      <div class="narrow-column">
+        <div class="image-plus">
+          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1772776099/Nivedita_qdnhhc.jpg",
+          "Nivedita Paul",
           ["auto", "425"] %}
-                </div>
-            </div>
-            <div class="wide-column flow-inbetween">
-                <h2>Pavithra Reddy</h2>
-                <p>
-          Pavithra lives at a neighbouring farm and started her Odissi training in Nrityagram’s rural outreach programme in 1990. She was the first student to graduate from Nrityagram’s rural outreach programme.
-        </p>
-                <p>
-          She learned Odissi under the tutelage of <a href="/surupa" class="bodylink">Surupa Sen</a> and has worked with dancers and movement specialists from across the globe.
-        </p>
-                <p>
-          Pavithra joined the Nrityagram Dance Ensemble 1993 and has performed solo and with the Ensemble at some of the most prestigious venues across India and the world.
-        </p>
-                <p>
-          In addition to being a full-time performer, Pavithra teaches in Nrityagram’s residential and outreach programs and is the Director of Outreach Activities.
-        </p>
-            </div>
         </div>
-
+      </div>
+      <div class="wide-column flow-inbetween">
+        <h2>Nivedita Paul</h2>
+        <p>Nivedita Paul is an educator and researcher committed to children’s wellbeing, learning, and creative development. She is the founder of <a href="https://p3m.ai" target="_blank" class="bodylink">Pen Pencil Paper and More</a> , an EdTech and empowerment initiative, and has held several leadership and teaching roles in education, including Founding Principal at Ramakrishna Mission School in Kozhikode, Homeroom Tutor at the Aga Khan Academy in Hyderabad, and Teach for India Fellow in Mumbai.</p>
+        <p>
+              Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of Pavithra Reddy, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
+            </p>
+        <p>
+              She teaches the youngest students in Nrityagram’s outreach programme, bringing together her experience as an educator and her love for dance to introduce children to the beauty and joy of Odissi.
+            </p>
+      </div>
     </div>
+
+    <div class="uneven-columns wide-grid-gap wide-narrow-60-40">
+      <div class="wide-column flow-inbetween">
+        <h2>Nandakishore K.R.</h2>
+        <p>Nandakishore K.R. is a theatre practitioner, lighting designer, mime artist, and movement designer with over three decades of experience in Indian theatre. He has collaborated with many of the country’s most distinguished theatre directors, including B.V. Karanth, Ebrahim Alkazi, Bansi Kaul, Ramgopal Bajaj, C. Basavalingaiah, V. Ramamurthy, and Habib Tanvir.</p>
+        <p>
+              An active member of the Kannada amateur theatre movement, he has also worked with artists such as Shankar Nag, Prema Karanth, B. Jayashree, and Suresh Anagalli. His work spans lighting design, directing children’s theatre, visual art collaborations, and film and television, where he has worked as a director, art director, scriptwriter, and producer.
+            </p>
+        <p>
+              Associated with Nrityagram since its inception, Nandakishore brings his rich experience in theatre, movement, and storytelling to creative work with young performers.
+            </p>
+      </div>
+      <div class="narrow-column">
+        <div class="image-plus">
+          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1772776107/Kishore_kkvqys.jpg",
+          "Nandakishore K.R.",
+          ["auto", "425"] %}
+        </div>
+      </div>
+    </div>
+
+    <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
+      <div class="narrow-column">
+        <div class="image-plus">
+          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739366969/shruti_jasani_fadvlv.jpg",
+          "Shruti Jasani",
+          ["auto", "425"] %}
+        </div>
+      </div>
+      <div class="wide-column flow-inbetween">
+        <h2>Shruti Jasani</h2>
+        <p>Shruti Jasani is a performer and movement teacher whose work spans contemporary dance, ballet, theatre, and aerial arts. She studied contemporary dance and ballet at New York University and has been affiliated with Trinity College London since 2005, where she specialised in the Performing Arts syllabus, completing professional examinations and teaching dance and drama.</p>
+        <p>She has also trained at Aerial Arts New York and with Womack and Bowman, and is the co-founder of The Wooden Stage, a studio where she teaches aerial arts to both children and adults. In addition to teaching, Shruti has performed widely in theatre and public events, including appearances at TEDx and TiEcon, and currently plays Kaa the python in the musical production The Jungle Book – Part 2.</p>
+        <p>At the Summer Camp, Shruti will lead sessions in Aerial Silk Movement and Body Conditioning, inviting young participants to experience strength, balance, and imagination in motion.</p>
+      </div>
+    </div>
+
+    <!-- <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
+          <div class="narrow-column">
+              <div class="image-plus">
+                  {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739369921/pavi-reddy-summer-fun_moh4q7.png", "Pavithra Reddy", ["auto", "425"] %}
+              </div>
+          </div>
+          <div class="wide-column flow-inbetween">
+            <h2>Pavithra Reddy</h2>
+            <p>Pavithra lives at a neighbouring farm and started her Odissi training in Nrityagram’s rural outreach programme in 1990. She was the first student to graduate from Nrityagram’s rural outreach programme.
+            </p>
+            <p>She learned Odissi under the tutelage of <a href="/surupa" class="bodylink">Surupa Sen</a> and has worked with dancers and movement specialists from across the globe.
+            </p>
+            <p>
+            Pavithra joined the Nrityagram Dance Ensemble 1993 and has performed solo and with the Ensemble at some of the most prestigious venues across India and the world.
+            </p>
+            <p>
+            In addition to being a full-time performer, Pavithra teaches in Nrityagram’s residential and outreach programs and is the Director of Outreach Activities.
+            </p>
+          </div>
+        </div> -->
+
+  </div>
 </div>
 <div class="container accent-bg">
-    <div class="wrapper flow">
-        <h1 class="center">About Kula: Artistes Residence</h1>
-        <div class="image-plus top-flow">
-            {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
+  <div class="wrapper flow">
+    <h1 class="center">About Kula: Artistes Residence</h1>
+    <div class="image-plus top-flow">
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
       "Kula Artistes Residence",
       ["560", "768", "1046"] %}
-            <div class="credit" data-image-credit="Rupert Lorhalder" ></div>
-        </div>
-        <p>
+      <div class="credit" data-image-credit="Rupert Lorhalder" ></div>
+    </div>
+    <p>
       The participants will stay in our artistes residence - <a href="/kula-artistes-residence" class="bodylink">Kula</a>, which has 8 rooms (2-3 beds per room) with ensuite bathrooms, a common kitchenette (for refreshments and snacks) and a courtyard.
     </p>
-        <p>
+    <p>
       All the teachers and students of Nrityagram stay within the campus in houses and rooms near Kula and camp participants will be supervised by an adult at all times. All meals and refreshments will be in the common dining area and are primarily vegetarian. 
     </p>
-        <p>
+    <p>
       In addition to engaging in dance and theatre workshops, camp participants will also be introduced to elements of organic gardening, bird watching and environmental awareness in what is today Bangalore’s only remaining grassland in Hessaraghatta.
     </p>
-    </div>
+  </div>
 </div>
 <div class="container">
-    <div class="wrapper flow">
-        <h1 class="center">Important Notes</h1>
-        <p>
+  <div class="wrapper flow">
+    <h1 class="center">Important Notes</h1>
+    <p>
       Careful planning and supervision helps us to provide a safe environment for everyone. Parents must be aware however, that Nrityagram is a rural location and we spend a lot of time outdoors and children will be involved in physical activities including but not limited to their classrooms, climbing trees and outdoor play.
     </p>
-        <p>
+    <p>
       If you have questions or concerns, please email us your phone number and we will return your call. 
     </p>
-        <p>
+    <p>
       Email: <a href="mailto:pavithra@nrityagram.org" class="bodylink">pavithra@nrityagram.org</a>
-        </p>
-    </div>
+    </p>
+  </div>
 </div>
 <div class="container accent-bg">
-    <div class="wrapper flow">
-        <h1 class="center">Details</h1>
-        <ul class="extra-margin-top no-bullets">
-            <li>
-                <b>Age</b>: 7 - 12 years
+  <div class="wrapper flow">
+    <h1 class="center">Details</h1>
+    <ul class="extra-margin-top no-bullets">
+      <li>
+        <b>Age</b>: 7 - 12 years
       </li>
-            <li>
-                <ul class="no-bullets">
-                    <li>
-                        <b>Arrival Date</b>: 13 April 2025, 3 - 5pm
+      <li>
+        <ul class="no-bullets">
+          <li>
+            <b>Arrival Date</b>: 28th April 2026, 3 - 5pm
           </li>
-                    <li>
-                        <b>Departure Date</b>: 18 April 2025, 3 - 5pm
+          <li>
+            <b>Departure Date</b>: 3rd May 2026, 3 - 5pm
           </li>
-                    <li>
+          <li>
             The start date is non-negotiable.
           </li>
-                </ul>
-            </li>
-            <li>
-                <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
+        </ul>
       </li>
-            <li>
-                <b>Enrolment & Payment Terms</b>
-                <ul >
-                    <li>
+      <li>
+        <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
+      </li>
+      <li>
+        <b>Enrolment & Payment Terms</b>
+        <ul >
+          <li>
             We accept students on a first-come first-served basis, and due to the high level of interest and limited space, we suggest that you sign up immediately, in order to secure a place.
           </li>
-                    <li>
+          <li>
             The full tuition fee must be paid in advance to reserve a place in the Camp. This amount is non-refundable unless we cancel the Camp.
           </li>
-                    <li>
+          <li>
             Upon receipt of the tuition fee, you will receive a confirmation of payment. Please check your Spam Folder in case it ends up there.
           </li>
-                </ul>
-            </li>
         </ul>
+      </li>
+    </ul>
 
-        <div class="razorpay-embed-btn center"
-                 data-url="https://pages.razorpay.com/pl_Pury7q2u6R7N7j/view"
-                 data-text="ALL SEATS BOOKED"
-                 data-color="#a5a5a5"
-                 disabled
-                 aria-disabled="true"
+    <!-- data-text="ALL SEATS BOOKED" data-color="#a5a5a5" disabled aria-disabled="true"-->
+    <div class="razorpay-embed-btn center"
+                 data-url="https://rzp.io/rzp/summer-fun-2026"
+                 data-text="Pay Registration Fee"
+                 data-color="#C91D25"
                  data-size="large">
 
-            <script>
-                (function () {
-                    var d = document;
-                    var x = !d.getElementById('razorpay-embed-btn-js')
-                    if (x) {
-                        var s = d.createElement('script');
-                        s.defer = !0;
-                        s.id = 'razorpay-embed-btn-js';
-                        s.src = 'https://cdn.razorpay.com/static/embed_btn/bundle.js';
-                        d
-                            .body
-                            .appendChild(s);
-                    } else {
-                        var rzp = window['__rzp__'];
-                        rzp && rzp.init && rzp.init()
-                    }
-                })();
-            </script>
-        </div>
-
-        <ul class="extra-margin-top no-bullets">
-            <li>
-                <b>Registration</b>: To complete registration, we will provide a link to the registration form that will need to be completed prior to the start of the Camp.
-      </li>
-            <li>
-                <b>Preparing for the Camp</b>: By mid-March, we will provide detailed information including guidelines, packing list, daily class schedule, etc.
-      </li>
-            <li>
-                <b>How to get to Nrityagram</b>: <a href="/findyourway" class="bodylink">Directions</a>
-            </li>
-        </ul>
+      <script>
+        (function () {
+          var d = document;
+          var x = !d.getElementById('razorpay-embed-btn-js')
+          if (x) {
+            var s = d.createElement('script');
+            s.defer = !0;
+            s.id = 'razorpay-embed-btn-js';
+            s.src = 'https://cdn.razorpay.com/static/embed_btn/bundle.js';
+            d
+              .body
+              .appendChild(s);
+          } else {
+            var rzp = window['__rzp__'];
+            rzp && rzp.init && rzp.init()
+          }
+        })();
+      </script>
     </div>
+
+    <ul class="extra-margin-top no-bullets">
+      <li>
+        <b>Registration</b>: To complete registration, we will provide a link to the registration form that will need to be completed prior to the start of the Camp.
+      </li>
+      <li>
+        <b>Preparing for the Camp</b>: By mid-March, we will provide detailed information including guidelines, packing list, daily class schedule, etc.
+      </li>
+      <li>
+        <b>How to get to Nrityagram</b>: <a href="/findyourway" class="bodylink">Directions</a>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/netlify/functions/preview/src/summer-workshop.njk
+++ b/netlify/functions/preview/src/summer-workshop.njk
@@ -9,6 +9,7 @@ title: "Summer Workshop"
 scrollToTop: true
 description: "Summer Workshop is a unique short-term programme in Odissi basics as developed and practised at Nrityagram, which also brings to students a compact experience of our philosophy of practising art as a way of life."
 OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1743082932/summer-workshop-og_ptykjy.png"
+archive: true
 ---
 <div id="banner-container">
     <div class="banner-image">

--- a/src/_includes/cta-desk.njk
+++ b/src/_includes/cta-desk.njk
@@ -6,7 +6,7 @@
          loading="lazy">
     <div class="cta-textbox">
         <div class="cta-line-lrg">Summer Fun for Kids</div>
-        <div class="cta-line-sml">13 - 18 April 2026</div>
+        <div class="cta-line-sml">28 April - 3 May 2026</div>
         <div class="cta-line-sml">Registrations Open</div>
     </div>
 </div>

--- a/src/_includes/cta-desk.njk
+++ b/src/_includes/cta-desk.njk
@@ -1,12 +1,12 @@
 <div class="cta-desk"
-       onclick="location.href='/virtual-steps';">
-    <img src="https://res.cloudinary.com/nrityagram/image/upload/w_200/v1748004445/virtual-steps-cta_yp7fcg.png"
-         alt="Virtual Steps CTA picture"
+       onclick="location.href='/summer-fun-for-kids';">
+    <img src="https://res.cloudinary.com/nrityagram/image/upload/v1739448387/summer-fun-cta_v2i7bb.png"
+         alt="Summer Fun for Kids 2026 picture"
          width="200"
          loading="lazy">
     <div class="cta-textbox">
-        <div class="cta-line-lrg">Virtual Steps</div>
-        <div class="cta-line-sml">New Batch Starts on 5 July 2025</div>
-        <div class="cta-line-sml">Registration Closed</div>
+        <div class="cta-line-lrg">Summer Fun for Kids</div>
+        <div class="cta-line-sml">13 - 18 April 2026</div>
+        <div class="cta-line-sml">Registrations Open</div>
     </div>
 </div>

--- a/src/_includes/cta-mobile.njk
+++ b/src/_includes/cta-mobile.njk
@@ -3,6 +3,6 @@
     <div class="cta-line-lrg">
         <span class="whitetext">Summer Fun for Kids</span>
     </div>
-    <div class="cta-line-sml">13 - 18 April 2026 • Registrations Open</div>
+    <div class="cta-line-sml">28 April - 3 May 2026 • Registrations Open</div>
     <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
 </div>

--- a/src/_includes/cta-mobile.njk
+++ b/src/_includes/cta-mobile.njk
@@ -1,8 +1,8 @@
 <div class="cta-mobile"
-             onclick="location.href='/virtual-steps';">
+             onclick="location.href='/summer-fun-for-kids';">
     <div class="cta-line-lrg">
-        <span class="whitetext">Virtual Steps</span>
+        <span class="whitetext">Summer Fun for Kids</span>
     </div>
-    <div class="cta-line-sml">New Batch starts on 5 July 2025 • Registration Closed</div>
+    <div class="cta-line-sml">13 - 18 April 2026 • Registrations Open</div>
     <div class="cta-arrow"><img src="/img/cta-arrow-circle-right.svg" alt=""></div>
 </div>

--- a/src/danceunlimited.njk
+++ b/src/danceunlimited.njk
@@ -71,21 +71,10 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1717245209/d
     </div>
     <h2 class="center">Summer Fun for Kids</h2>
     <p>
-			Our Summer Fun for Kids is a unique residential workshop designed to help young ones understand community
-			living. Every year a small group of children enrol in this workshop to find out for themselves,
-			what is the Nrityagram way of life. Far away from television sets and video games, surrounded by lush foliage,
-			beautiful birds and flowering trees, they experience life in a place where all residents take care of themselves
-			and their home, and the cornerstone for the entire community is mindful living and the pursuit of excellence. 
+      <b>Summer Fun for Kids</b> is a residential workshop that offers children a glimpse into the Nrityagram way of life. Surrounded by nature and away from everyday distractions, participants spend their days immersed in dance while experiencing the rhythms of community living. Along with dance sessions, children enjoy nature walks, storytelling, games, and creative exploration. For many participants - and their parents - the experience becomes truly <b>life-changing</b>. 
 		</p>
     <p>
-			The focus is dance but they also go for
-			nature walks, tell stories, play games and most importantly, have lots of fun.
-		</p>
-    <p>	
-			Most of the children (and their parents) describe the experience as “life changing”.
-		</p>
-    <p>
-      <a href="/summer-fun-for-kids" class="bodylink">Summer Fun for Kids 2025</a>
+      <a href="/summer-fun-for-kids" class="bodylink">Summer Fun for Kids 2026</a>
     </p>
     <div class="image-plus top-flow">
       {% image "https://res.cloudinary.com/nrityagram/image/upload/c_scale,w_800/v1580737468/3_NG101_r33pqg.jpg",

--- a/src/danceunlimited.njk
+++ b/src/danceunlimited.njk
@@ -69,7 +69,12 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1717245209/d
       ["560", "768", "1046"] %}
       <div class="credit" data-image-credit="Dhruvatara Sharma" ></div>
     </div>
-    <h2 class="center">Summer Fun for Kids</h2>
+    <span class="center">
+      <h2>Summer Fun for Kids</h2>
+      <h4>
+      Live. Move. Discover.
+    </h4>
+    </span>
     <p>
       <b>Summer Fun for Kids</b> is a residential workshop that offers children a glimpse into the Nrityagram way of life. Surrounded by nature and away from everyday distractions, participants spend their days immersed in dance while experiencing the rhythms of community living. Along with dance sessions, children enjoy nature walks, storytelling, games, and creative exploration. For many participants - and their parents - the experience becomes truly <b>life-changing</b>. 
 		</p>

--- a/src/friendsofng.njk
+++ b/src/friendsofng.njk
@@ -10,6 +10,7 @@ parentMenuItem: "Support"
 title: "Friends of Nrityagram"
 description: "Friends of Nrityagram are vital members of our extended family. Your support will help us maintain the institution and further expand it. India’s first modern Gurukul, Nrityagram is a one-of-a-kind community where dance is a way of life."
 OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1570033516/friends-of-nrityagram-banner_fg7kzg.jpg"
+archive: true
 ---
 <div id="banner-container">
   <div class="banner-image">

--- a/src/index.njk
+++ b/src/index.njk
@@ -9,7 +9,7 @@ slider: true
 youtube: true
 marquee: true
 scrollToTop: true
-cta: false
+cta: true
 date: Last Modified
 OGImage: 'https://res.cloudinary.com/nrityagram/image/upload/v1701794529/ng_logo_blk_bg_sg0emm.png'
 ---

--- a/src/informance.njk
+++ b/src/informance.njk
@@ -8,6 +8,7 @@ date: Last Modified
 title: "Informance"
 description: "Fun and interesting activities to do in Nrityagram - guided tours and lecture-demonstrations."
 OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1731612495/nov2024-informance-desk_yy24de.png"
+archive: true
 ---
 <div id="banner-container">
   <div class="banner-image">

--- a/src/makeadonation-usa.njk
+++ b/src/makeadonation-usa.njk
@@ -28,7 +28,8 @@ description: "Any amount you donate will make it possible for us to strengthen o
       </a>.
     </p>
     <p>
-      Phoenix Theatre Ensemble is a 501(c)(3) not-for-profit organization EIN # 20-1562809.
+      <!-- Break up the number formatting to prevent safari from automatically detecting the EIN number as a phone number -->
+      Phoenix Theatre Ensemble is a 501(c)(3) not-for-profit organization EIN # 20-1562<span style="display:none;">.</span>809.
     </p>
     <p>
       Your contribution is <strong>tax-deductible</strong> to the fullest extent allowed by law.   

--- a/src/makeadonation-usa.njk
+++ b/src/makeadonation-usa.njk
@@ -28,8 +28,8 @@ description: "Any amount you donate will make it possible for us to strengthen o
       </a>.
     </p>
     <p>
-      <!-- Break up the number formatting to prevent safari from automatically detecting the EIN number as a phone number -->
-      Phoenix Theatre Ensemble is a 501(c)(3) not-for-profit organization EIN # 20-1562<span style="display:none;">.</span>809.
+      <!-- Wrap the number in semantic tags to prevent safari from automatically detecting the EIN number as a phone number -->
+      Phoenix Theatre Ensemble is a 501(c)(3) not-for-profit organization EIN # <code>20-1562809</code>.
     </p>
     <p>
       Your contribution is <strong>tax-deductible</strong> to the fullest extent allowed by law.   

--- a/src/robots.njk
+++ b/src/robots.njk
@@ -5,5 +5,10 @@ permalink: /robots.txt
 User-agent: *
 Allow: /
 Disallow: /pagetemplate
+{%- for page in collections.all %}
+{%- if page.data.archive %}
+Disallow: {{ page.url }}
+{%- endif %}
+{%- endfor %}
 
 Sitemap: {{ metadata.url }}/sitemap.xml

--- a/src/sass/utilities/_columns.scss
+++ b/src/sass/utilities/_columns.scss
@@ -2,432 +2,411 @@
 @use 'flow' as *;
 @use '../abstracts/' as *;
 
-
 .left-column {
-    grid-area: leftcol;
+	grid-area: leftcol;
 }
 
 .right-column {
-    grid-area: rightcol;
+	grid-area: rightcol;
 }
 
 .narrow-column {
-    grid-area: narrowcol;
+	grid-area: narrowcol;
 
-    @include mqmax(medium) {
-        align-self: center;
-    }
+	@include mqmax(medium) {
+		align-self: center;
+	}
 }
 
 .narrow-column :where(:not(:first-child)) {
-    margin-top: var(--flow-spacer-close);
+	margin-top: var(--flow-spacer-close);
 }
 
 .wide-column {
-    grid-area: widecol;
+	grid-area: widecol;
 
-    @include mqmax(medium) {
-        align-self: center;
-    }
+	@include mqmax(medium) {
+		align-self: center;
+	}
 }
 
 .spacer-column {
-    grid-area: spacercol;
+	grid-area: spacercol;
 }
 
 .center-column {
-    padding-left: 25%;
-    padding-right: 25%;
+	padding-left: 25%;
+	padding-right: 25%;
 
-    @include mqmax(medium) {
-        padding-left: 0;
-        padding-right: 0;
-    }
+	@include mqmax(medium) {
+		padding-left: 0;
+		padding-right: 0;
+	}
 }
-
 
 // TODO: make a sass/layouts folder to implement specific layout designs such pullquote-column, narrow-wide-40-60, etc.
 
 .even-columns-unlimited {
-    @extend .grid;
-    place-items: center;
+	@extend .grid;
+	place-items: center;
 
-    // For ipad mini (portrait) we want slideup cards to appear 2x2,
-    // hence a different medium berakpoint at 720px instead of 800px
-    @include mq(medium2) {
-        grid-template-columns: repeat(2, 1fr);
-    }
+	// For ipad mini (portrait) we want slideup cards to appear 2x2,
+	// hence a different medium berakpoint at 720px instead of 800px
+	@include mq(medium2) {
+		grid-template-columns: repeat(2, 1fr);
+	}
 
-    @include mq(large2) {
-        grid-auto-flow: column;
-        grid-auto-columns: 1fr;
-    }
+	@include mq(large2) {
+		grid-auto-flow: column;
+		grid-auto-columns: 1fr;
+	}
 
-    &.center-column-pair {
-        grid-auto-flow: column;
-        grid-auto-columns: 1fr;
+	&.center-column-pair {
+		grid-auto-flow: column;
+		grid-auto-columns: 1fr;
 
-        // For mobile, the pair of columns will be stacked
-        .column-1 {
-            grid-row: 1 / 2;
-            grid-column: 1 / 2;
-        }
+		// For mobile, the pair of columns will be stacked
+		.column-1 {
+			grid-row: 1 / 2;
+			grid-column: 1 / 2;
+		}
 
-        .column-2 {
-            grid-row: 2 / 3;
-            grid-column: 1 / 2;
-        }
+		.column-2 {
+			grid-row: 2 / 3;
+			grid-column: 1 / 2;
+		}
 
-        @include mq(medium) {
-            grid-template-columns: repeat(2, 1fr);
+		@include mq(medium) {
+			grid-template-columns: repeat(2, 1fr);
 
-            .column-1 {
-                grid-row: 1 / 2;
-                grid-column: 1 / 2;
-            }
+			.column-1 {
+				grid-row: 1 / 2;
+				grid-column: 1 / 2;
+			}
 
-            .column-2 {
-                grid-row: 1 / 2;
-                grid-column: 2 / 3;
-            }
-        }
+			.column-2 {
+				grid-row: 1 / 2;
+				grid-column: 2 / 3;
+			}
+		}
 
-        @include mq(large) {
-            grid-template-columns: repeat(4, 1fr);
+		@include mq(large) {
+			grid-template-columns: repeat(4, 1fr);
 
-            .column-1 {
-                grid-row: 1 / 2;
-                grid-column: 2 / 3;
-            }
+			.column-1 {
+				grid-row: 1 / 2;
+				grid-column: 2 / 3;
+			}
 
-            .column-2 {
-                grid-row: 1 / 2;
-                grid-column: 3 / 4;
-            }
-        }
-    }
+			.column-2 {
+				grid-row: 1 / 2;
+				grid-column: 3 / 4;
+			}
+		}
+	}
 
-    &.textbox-card-pair {
-        grid-auto-flow: column;
-        grid-auto-columns: 1fr;
+	&.textbox-card-pair {
+		grid-auto-flow: column;
+		grid-auto-columns: 1fr;
 
-        // For mobile, the pair of columns will be stacked
-        .textbox-column {
-            grid-row: 1 / 2;
-            grid-column: 1 / 2;
-        }
+		// For mobile, the pair of columns will be stacked
+		.textbox-column {
+			grid-row: 1 / 2;
+			grid-column: 1 / 2;
+		}
 
-        .card-column {
-            grid-row: 2 / 3;
-            grid-column: 1 / 2;
-        }
+		.card-column {
+			grid-row: 2 / 3;
+			grid-column: 1 / 2;
+		}
 
-        // tablet
-        // Using medium2 breakpoint to have 
-        // two equal columns for ipad mini
-        @include mq(medium2) {
-            grid-template-columns: repeat(2, 1fr);
+		// tablet
+		// Using medium2 breakpoint to have
+		// two equal columns for ipad mini
+		@include mq(medium2) {
+			grid-template-columns: repeat(2, 1fr);
 
-            // textbox will be first column
-            .textbox-column {
-                grid-row: 1 / 2;
-                grid-column: 1 / 2;
-            }
+			// textbox will be first column
+			.textbox-column {
+				grid-row: 1 / 2;
+				grid-column: 1 / 2;
+			}
 
-            .card-column {
-                grid-row: 1 / 2;
-                grid-column: 2 / 3;
-            }
-        }
+			.card-column {
+				grid-row: 1 / 2;
+				grid-column: 2 / 3;
+			}
+		}
 
-        // desktop (large screens)
-        @include mq(large) {
-            grid-template-columns: repeat(3, 1fr);
+		// desktop (large screens)
+		@include mq(large) {
+			grid-template-columns: repeat(3, 1fr);
 
-            // textbox will be 1st and 2nd columns
-            .textbox-column {
-                grid-row: 1 / 2;
-                grid-column: 1 / 3;
-            }
+			// textbox will be 1st and 2nd columns
+			.textbox-column {
+				grid-row: 1 / 2;
+				grid-column: 1 / 3;
+			}
 
-            // card column will be 3rd column
-            .card-column {
-                grid-row: 1 / 2;
-                grid-column: 3 / 4;
-            }
-        }
-    }
+			// card column will be 3rd column
+			.card-column {
+				grid-row: 1 / 2;
+				grid-column: 3 / 4;
+			}
+		}
+	}
 
-    // case: multiple buttons in a row
-    // make width of all buttons equal
-    .button {
-        // TODO: need to take larger value of fit-content and 75% of width
-        width: 75%;
-    }
+	// case: multiple buttons in a row
+	// make width of all buttons equal
+	.button {
+		// TODO: need to take larger value of fit-content and 75% of width
+		width: 75%;
+	}
 }
-
 
 .even-columns {
-    @extend .grid;
-    grid-template-columns: 100%;
-    grid-template-areas:
-        "leftcol"
-        "rightcol";
+	@extend .grid;
+	grid-template-columns: 100%;
+	grid-template-areas:
+		'leftcol'
+		'rightcol';
 
-    @include mq(medium) {
-        grid-template-columns: 1fr 1fr;
-        grid-template-areas:
-            "leftcol rightcol";
-    }
+	@include mq(medium) {
+		grid-template-columns: 1fr 1fr;
+		grid-template-areas: 'leftcol rightcol';
+	}
 
-    &.reverse-mob {
+	&.reverse-mob {
+		// mobile
+		@include mqmax(medium) {
+			grid-template-columns: 100%;
+			grid-template-areas:
+				'rightcol'
+				'leftcol';
+		}
+	}
 
-        // mobile
-        @include mqmax(medium) {
-            grid-template-columns: 100%;
-            grid-template-areas:
-                "rightcol"
-                "leftcol";
-        }
-    }
+	&.reverse-tab {
+		// tablet
+		@include mqmax(large) {
+			grid-template-columns: 100%;
+			grid-template-areas:
+				'rightcol'
+				'leftcol';
+		}
+	}
 
-    &.reverse-tab {
+	&.hide-right-mob {
+		// mobile
+		@include mqmax(medium) {
+			.right-column {
+				display: none;
+			}
+		}
+	}
 
-        // tablet
-        @include mqmax(large) {
-            grid-template-columns: 100%;
-            grid-template-areas:
-                "rightcol"
-                "leftcol";
-        }
-    }
-
-    &.hide-right-mob {
-
-        // mobile
-        @include mqmax(medium) {
-            .right-column {
-                display: none;
-            }
-        }
-    }
-
-    &.hide-left-mob {
-
-        // mobile
-        @include mqmax(medium) {
-            .left-column {
-                display: none;
-            }
-        }
-    }
+	&.hide-left-mob {
+		// mobile
+		@include mqmax(medium) {
+			.left-column {
+				display: none;
+			}
+		}
+	}
 }
 
-
 .uneven-columns {
-    @extend .grid;
+	@extend .grid;
 
-    // narrow | wide columns
-    &.narrow-wide {
-        grid-template-columns: 100%;
-        grid-template-areas:
-            "narrowcol"
-            "widecol";
+	// narrow | wide columns
+	&.narrow-wide {
+		grid-template-columns: 100%;
+		grid-template-areas:
+			'narrowcol'
+			'widecol';
 
-        @include mq(medium) {
-            grid-template-columns: 34% 63%;
-            grid-template-areas:
-                "narrowcol widecol";
-        }
-    }
+		@include mq(medium) {
+			grid-template-columns: 34% 63%;
+			grid-template-areas: 'narrowcol widecol';
+		}
+	}
 
-    // narrow | wide columns with pullquote in narrow
-    &.pullquote-column {
-        grid-template-columns: 100%;
-        grid-template-areas:
-            "narrowcol"
-            "widecol";
+	// narrow | wide columns with pullquote in narrow
+	&.pullquote-column {
+		grid-template-columns: 100%;
+		grid-template-areas:
+			'narrowcol'
+			'widecol';
 
-        @include mq(medium) {
-            grid-template-columns: 24% 67% 6%;
-            grid-template-areas:
-                "narrowcol widecol spacercol";
-        }
+		@include mq(medium) {
+			grid-template-columns: 24% 67% 6%;
+			grid-template-areas: 'narrowcol widecol spacercol';
+		}
 
-        @include mq(medium) {
-            .image-plus {
-                width: 85% !important;
-                margin-left: auto !important;
-                margin-right: 0 !important;
-            }
-        }
+		@include mq(medium) {
+			.image-plus {
+				width: 85% !important;
+				margin-left: auto !important;
+				margin-right: 0 !important;
+			}
+		}
 
-        @include mq(large) {
-            .image-plus {
-                width: 95% !important;
-                margin-left: auto !important;
-                margin-right: 0 !important;
-            }
-        }
+		@include mq(large) {
+			.image-plus {
+				width: 95% !important;
+				margin-left: auto !important;
+				margin-right: 0 !important;
+			}
+		}
 
-        &.reverse-mob {
+		&.reverse-mob {
+			// mobile
+			@include mqmax(medium) {
+				grid-template-areas:
+					'widecol'
+					'narrowcol';
+			}
+		}
+	}
 
-            // mobile
-            @include mqmax(medium) {
-                grid-template-areas:
-                    "widecol"
-                    "narrowcol";
-            }
-        }
-    }
+	&.narrow-wide-40-60 {
+		grid-template-columns: 100%;
+		grid-template-areas:
+			'narrowcol'
+			'widecol';
 
-    &.narrow-wide-40-60 {
-        grid-template-columns: 100%;
-        grid-template-areas:
-            "narrowcol"
-            "widecol";
+		@include mq(medium) {
+			// auto takes care of wide-grid-gap and does not overflow from the grid
+			grid-template-columns: 40% auto;
+			grid-template-areas: 'narrowcol widecol';
+		}
+	}
 
-        @include mq(medium) {
-            // auto takes care of wide-grid-gap and does not overflow from the grid
-            grid-template-columns: 40% auto;
-            grid-template-areas:
-                "narrowcol widecol";
-        }
-    }
+	&.narrow-wide,
+	&.narrow-wide-40-60 {
+		&.reverse-mob {
+			// mobile
+			@include mqmax(medium) {
+				grid-template-areas:
+					'widecol'
+					'narrowcol';
+			}
+		}
 
-    &.narrow-wide,
-    &.narrow-wide-40-60 {
-        &.reverse-mob {
+		&.reverse-tab {
+			// tablet
+			@include mqmax(large) {
+				grid-template-areas:
+					'widecol'
+					'narrowcol';
+			}
+		}
+	}
 
-            // mobile
-            @include mqmax(medium) {
-                grid-template-areas:
-                    "widecol"
-                    "narrowcol";
-            }
-        }
+	// wide | narrow columns
+	&.wide-narrow {
+		grid-auto-columns: 100%;
+		grid-template-areas:
+			'widecol'
+			'narrowcol';
 
-        &.reverse-tab {
+		@include mq(medium) {
+			grid-template-columns: 63% 34%;
+			grid-template-areas: 'widecol narrowcol';
+		}
 
-            // tablet
-            @include mqmax(large) {
-                grid-template-areas:
-                    "widecol"
-                    "narrowcol";
-            }
-        }
-    }
+		&.reverse-mob {
+			// mobile
+			@include mqmax(medium) {
+				grid-template-areas:
+					'narrowcol'
+					'widecol';
+			}
+		}
 
-    // wide | narrow columns
-    &.wide-narrow {
-        grid-auto-columns: 100%;
-        grid-template-areas:
-            "widecol"
-            "narrowcol";
+		&.reverse-tab {
+			// tablet
+			@include mqmax(large) {
+				grid-template-areas:
+					'narrowcol'
+					'widecol';
+			}
+		}
+	}
 
-        @include mq(medium) {
-            grid-template-columns: 63% 34%;
-            grid-template-areas:
-                "widecol narrowcol";
-        }
+	&.wide-narrow-60-40 {
+		grid-template-columns: 100%;
+		grid-template-areas:
+			'widecol'
+			'narrowcol';
 
-        &.reverse-mob {
+		@include mq(medium) {
+			grid-template-columns: 60% auto;
+			grid-template-areas: 'widecol narrowcol';
+		}
+	}
 
-            // mobile
-            @include mqmax(medium) {
-                grid-template-areas:
-                    "narrowcol"
-                    "widecol";
-            }
-        }
+	&.wide-narrow,
+	&.wide-narrow-60-40 {
+		&.reverse-mob {
+			// mobile
+			@include mqmax(medium) {
+				grid-template-areas:
+					'narrowcol'
+					'widecol';
+			}
+		}
 
-        &.reverse-tab {
-
-            // tablet
-            @include mqmax(large) {
-                grid-template-areas:
-                    "narrowcol"
-                    "widecol";
-            }
-        }
-    }
-
-    &.wide-narrow-60-40 {
-        grid-template-columns: 100%;
-        grid-template-areas:
-            "widecol"
-            "narrowcol";
-
-        @include mq(medium) {
-            grid-template-columns: auto 40%;
-            grid-template-areas:
-                "widecol narrowcol";
-        }
-    }
-
-    &.wide-narrow,
-    &.wide-narrow-60-40 {
-        &.reverse-mob {
-
-            // mobile
-            @include mqmax(medium) {
-                grid-template-areas:
-                    "narrowcol"
-                    "widecol";
-            }
-        }
-
-        &.reverse-tab {
-
-            // tablet
-            @include mqmax(large) {
-                grid-template-areas:
-                    "narrowcol"
-                    "widecol";
-            }
-        }
-    }
+		&.reverse-tab {
+			// tablet
+			@include mqmax(large) {
+				grid-template-areas:
+					'narrowcol'
+					'widecol';
+			}
+		}
+	}
 }
 
 // all direct children in this column are stacked one above the other
 .stacked-column {
-    display: grid;
-    grid-template-columns: 1fr;
+	display: grid;
+	grid-template-columns: 1fr;
 
-    >* {
-        grid-row-start: 1;
-        grid-column-start: 1;
-    }
+	> * {
+		grid-row-start: 1;
+		grid-column-start: 1;
+	}
 }
 
 .left-align-column {
-    text-align: left;
+	text-align: left;
 
-    @include mqmax(medium) {
-        // align-self: center;
-        // margin: 0 auto;
-        text-align: left;
-    }
+	@include mqmax(medium) {
+		// align-self: center;
+		// margin: 0 auto;
+		text-align: left;
+	}
 }
 
 .right-align-column {
-    text-align: right;
+	text-align: right;
 
-    @include mqmax(medium) {
-        // align-self: center;
-        // margin: 0 auto;
-        text-align: left;
-    }
+	@include mqmax(medium) {
+		// align-self: center;
+		// margin: 0 auto;
+		text-align: left;
+	}
 }
 
 .bottom-align-column {
-    align-self: end;
+	align-self: end;
 }
 
 .top-align-column {
-    align-self: start;
+	align-self: start;
 }
 
 .center-align-column {
-    align-self: center;
+	align-self: center;
 }

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -5,6 +5,7 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
     {%- for page in collections.all %}
+        {%- if not page.data.archive %}
         {% set absoluteUrl %}{{ page.url | htmlBaseUrl(metadata.url) }}{% endset %}
         <url>
             <loc>{{ absoluteUrl }}</loc>
@@ -12,5 +13,6 @@ eleventyExcludeFromCollections: true
             <changefreq>{{ page.data.sitemapChangefreq | default("monthly") }}</changefreq>
             <priority>{{ page.data.sitemapPriority | default(0.8) }}</priority>
         </url>
+        {%- endif %}
     {%- endfor %}
 </urlset>

--- a/src/summer-fun-for-kids.njk
+++ b/src/summer-fun-for-kids.njk
@@ -33,7 +33,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
   <div class="wrapper flow">
     <h3 class="center">Live. Move. Discover.</h3>
     <p>
-			A short drive from the bustle of Bangalore lies <b>Nrityagram Dance Village</b>, home to a community of dancers devoted to the pursuit of their art. The Nrityagram Dance Ensemble has performed across the world, earning international acclaim and numerous awards.
+			A short drive from the bustle of Bangalore lies <b>Nrityagram</b>, home to a community of dancers devoted to the pursuit of their art. The Nrityagram Dance Ensemble has performed across the world, earning international acclaim and numerous awards.
     </p>
     <p>
       <em>“The only proper response to dancers this amazing is worship.”</em>
@@ -56,7 +56,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       Dance and theatre have always been the core elements of the camp. This year, we are excited to introduce a new addition: <b>Aerial Silks</b>. In these sessions, participants explore movement on suspended silks, discovering the joy of moving through the air while developing strength, balance, coordination, and confidence.
     </p>
     <p>
-      The camp will be led by a team of experienced artists and educators. <b>Nivedita Paul</b>, a Nrityagram dancer and educator, will guide the Odissi dance sessions. <b>Nandakishore K.R.</b>, a theatre practitioner and long-time collaborator of Nrityagram, will lead movement and theatre classes. <b>Shruti Jasani</b>, performer and founder of The Wooden Stage in Mumbai, will lead sessions in Aerial Silks and Body Conditioning. 
+      The camp will be led by a team of experienced artistes and educators. <b>Nivedita Paul</b>, a Nrityagram dancer and educator, will guide the Odissi dance sessions. <b>Nandakishore K.R.</b>, a theatre practitioner and long-time collaborator of Nrityagram, will lead movement and theatre classes. <b>Shruti Jasani</b>, Nrityagram student and founder of The Wooden Stage in Mumbai, will lead sessions in Aerial Silks and Body Conditioning. 
     </p>
     <p>
       Throughout the camp, participants will live together on the Nrityagram campus, sharing the rhythms of village life while learning, creating, and <b>discovering new possibilities through movement, creativity, and imagination</b>. 
@@ -97,7 +97,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
     <span>
       <h1 class="center">Meet the Camp Mentors</h1>
       <p class="center">
-        <em>Artists and educators guiding creativity, movement, and discovery.</em>
+        <em>Artistes and educators guiding creativity, movement, and discovery.</em>
       </p>
     </span>
     <p>
@@ -116,7 +116,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Nivedita Paul</h2>
         <p>Nivedita Paul is an educator and researcher committed to children’s wellbeing, learning, and creative development. She is the founder of <a href="https://p3m.ai" target="_blank" class="bodylink">Pen Pencil Paper and More</a> , an EdTech and empowerment initiative, and has held several leadership and teaching roles in education, including Founding Principal at Ramakrishna Mission School in Kozhikode, Homeroom Tutor at the Aga Khan Academy in Hyderabad, and Teach for India Fellow in Mumbai.</p>
         <p>
-          Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of <a href="/pavithra" class="bodylink">Pavithra Reddy</a>, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
+          Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies through online classes with <a href="/surupa" class="bodylink">Surupa Sen</a> and since 2022,  as a Day Scholar under the guidance of <a href="/pavithra" class="bodylink">Pavithra Reddy</a>.
         </p>
         <p>
           She teaches the youngest students in Nrityagram’s outreach programme, bringing together her experience as an educator and her love for dance to introduce children to the beauty and joy of Odissi.
@@ -129,7 +129,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Nandakishore K.R.</h2>
         <p>Nandakishore K.R. is a theatre practitioner, lighting designer, mime artist, and movement designer with over three decades of experience in Indian theatre. He has collaborated with many of the country’s most distinguished theatre directors, including B.V. Karanth, Ebrahim Alkazi, Bansi Kaul, Ramgopal Bajaj, C. Basavalingaiah, V. Ramamurthy, and Habib Tanvir.</p>
         <p>
-          An active member of the Kannada amateur theatre movement, he has also worked with artists such as Shankar Nag, Prema Karanth, B. Jayashree, and Suresh Anagalli. His work spans lighting design, directing children’s theatre, visual art collaborations, and film and television, where he has worked as a director, art director, scriptwriter, and producer.
+          An active member of the Kannada amateur theatre movement, he has also worked with artistes such as Shankar Nag, Prema Karanth, B. Jayashree, and Suresh Anagalli. His work spans lighting design, directing children’s theatre, visual art collaborations, and film and television, where he has worked as a director, art director, scriptwriter, and producer.
         </p>
         <p>
           Associated with Nrityagram since its inception, Nandakishore brings his rich experience in theatre, movement, and storytelling to creative work with young performers.
@@ -155,7 +155,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       <div class="wide-column flow-inbetween">
         <h2>Shruti Jasani</h2>
         <p>Shruti Jasani is a performer and movement teacher whose work spans contemporary dance, ballet, theatre, and aerial arts. She studied contemporary dance and ballet at New York University and has been affiliated with Trinity College London since 2005, where she specialised in the Performing Arts syllabus, completing professional examinations and teaching dance and drama.</p>
-        <p>She has also trained at Aerial Arts New York and with Womack and Bowman, and is the co-founder of The Wooden Stage, a studio where she teaches aerial arts to both children and adults. In addition to teaching, Shruti has performed widely in theatre and public events, including appearances at TEDx and TiEcon, and currently plays Kaa the python in the musical production The Jungle Book – Part 2.</p>
+        <p>She has also trained at Aerial Arts New York and with Womack and Bowman, and is the co-founder of <a href="https://thewoodenstage.com/" target="_blank" class="bodylink">The Wooden Stage</a>, a studio where she teaches aerial arts to both children and adults. In addition to teaching, Shruti has performed widely in theatre and public events, including appearances at TEDx and TiEcon, and currently plays Kaa the python in the musical production The Jungle Book – Part 2.</p>
         <p>At the Summer Camp, Shruti will lead sessions in Aerial Silk Movement and Body Conditioning, inviting young participants to experience strength, balance, and imagination in motion.</p>
       </div>
     </div>
@@ -258,7 +258,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       <div class="credit" data-image-credit="Rupert Lorhaldar" ></div>
     </div>
     <p>
-      Located a short distance from Bangalore, <b>Nrityagram Dance Village</b> is a unique community dedicated to the pursuit of classical dance.
+      Located a short distance from Bangalore, <b>Nrityagram</b> is a unique community dedicated to the pursuit of Odissi dance.
     </p>
     <p>
       During the camp, participants live together on the campus, surrounded by flowering trees, birds, and open spaces. In this environment - free from screens and everyday distractions - children experience a mindful way of living where creativity, discipline, and community go hand in hand.
@@ -267,7 +267,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       The participants will stay in our artistes residence, Kula, which has 8 rooms (2-3 beds per room) with ensuite bathrooms, a common kitchenette (for refreshments and snacks) and a courtyard.
     </p>
     <p>
-      All the teachers and students of Nrityagram stay within the campus in houses and rooms near Kula and camp participants will be supervised by an adult at all times. All meals and refreshments will be in the common dining area and are primarily vegetarian.
+      All the teachers and students of Nrityagram live within the campus in houses and rooms near Kula and camp participants will be supervised by an adult at all times. All meals and refreshments will be in the common dining area and are primarily vegetarian.
     </p>
   </div>
 </div>
@@ -284,7 +284,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       <li>
         <b>Unique Creative Environment</b>
         <br>
-        Children spend their days immersed in dance, theatre, and movement within the inspiring surroundings of Nrityagram Dance Village.
+        Children spend their days immersed in dance, theatre, and movement within the inspiring surroundings of Nrityagram.
       </li>
       <li>&nbsp;</li>
       <li>
@@ -334,24 +334,16 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <b>Age</b>: 7 - 12 years
       </li>
       <li>
-        <ul class="no-bullets">
-          <li>
-            <b>Location</b>: Nrityagram
-          </li>
-          <li>
-            <b>Residential</b>: Yes
-          </li>
-        </ul>
+        <b>Location</b>: Nrityagram
       </li>
       <li>
-        <ul class="no-bullets">
-          <li>
-            <b>Number of Participants</b>: Limited places available
-          </li>
-          <li>
-            <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
-          </li>
-        </ul>
+        <b>Residential</b>: Yes
+      </li>
+      <li>
+        <b>Number of Participants</b>: Limited places available
+      </li>
+      <li>
+        <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
       </li>
       <li>
         <b>Enrolment & Payment Terms</b>

--- a/src/summer-fun-for-kids.njk
+++ b/src/summer-fun-for-kids.njk
@@ -31,33 +31,41 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
 </div>
 <div class="container">
   <div class="wrapper flow">
+    <h3 class="center">Live. Move. Discover.</h3>
     <p>
-			Far from the bustle of Bangalore lies <b>Nrityagram Dance Village</b>, home to a community of dancers who have devoted their lives to the pursuit of their art. The Nrityagram Dance Ensemble has performed across the world, earning international acclaim. As <em>The New York Times said, “The only proper response to dancers this amazing is worship!”</em>
+			A short drive from the bustle of Bangalore lies <b>Nrityagram Dance Village</b>, home to a community of dancers devoted to the pursuit of their art. The Nrityagram Dance Ensemble has performed across the world, earning international acclaim and numerous awards.
     </p>
-    <p>But what is daily life like in this remarkable place?</p>
+    <p>
+      <em>“The only proper response to dancers this amazing is worship.”</em>
+      <br />
+      <b>The New York Times</b>
+    </p>
+    <p>
+      But what is daily life like in this remarkable place?
+    </p>
     <p>
       Every year, a small group of children get the opportunity to find out by enrolling in <b>Nrityagram’s Summer Fun for Kids</b>. For a few special days, they experience life at Nrityagram through dance, theatre, storytelling, games, nature walks, and shared community activities.
     </p>
     <p>
-      <b>Summer Fun for Kids</b> is a unique short-term residential camp that offers participants a glimpse into the Nrityagram philosophy - where learning is not confined to a classroom, but lived as a way of life. Away from television screens and video games, and surrounded by flowering trees, birds, and open spaces, children experience a rhythm of living where everyone cares for themselves, their surroundings, and their shared home.
+      <b>Summer Fun for Kids</b> is a unique short-term residential camp that offers participants a glimpse into the Nrityagram philosophy - where learning is not confined to a classroom, but lived as a way of life. Away from television screens and video games, and surrounded by flowering trees, birds, and open spaces, children experience a rhythm of living where everyone learns to care for themselves, their surroundings, and their shared home.
     </p>
     <p>
       The camp also introduces children to the spirit of the <b>guru-shishya parampara</b> that guides learning at Nrityagram. Participants follow a five-hour daily learning schedule that includes dance and theatre sessions, along with yoga, body conditioning, and creative art activities. They also take part in simple everyday tasks such as cooking, gardening, and caring for the campus - becoming part of the community for the duration of the camp. Many children (and their parents) later describe the experience as truly life-changing.
     </p>
     <p>
-      Dance and theatre have always been the core elements of the camp. This year, we are excited to introduce a new addition: <b>Aerial Silk Work</b>.
+      Dance and theatre have always been the core elements of the camp. This year, we are excited to introduce a new addition: <b>Aerial Silks</b>. In these sessions, participants explore movement on suspended silks, discovering the joy of moving through the air while developing strength, balance, coordination, and confidence.
     </p>
     <p>
-      The camp will be led by a team of experienced artists and educators. <b>Nivedita Paul</b>, a Nrityagram dancer and educator, will guide the Odissi dance sessions. <b>Nandakishore K.R.</b>, a theatre practitioner and long-time collaborator of Nrityagram, will lead movement and theatre classes. <b>Shruti Jasani</b>, performer and founder of The Wooden Stage in Mumbai, will conduct sessions in Aerial Silk Movement and Body Conditioning.
+      The camp will be led by a team of experienced artists and educators. <b>Nivedita Paul</b>, a Nrityagram dancer and educator, will guide the Odissi dance sessions. <b>Nandakishore K.R.</b>, a theatre practitioner and long-time collaborator of Nrityagram, will lead movement and theatre classes. <b>Shruti Jasani</b>, performer and founder of The Wooden Stage in Mumbai, will lead sessions in Aerial Silks and Body Conditioning. 
     </p>
     <p>
-      Throughout the camp, participants will live together on the Nrityagram campus, sharing the rhythms of village life while learning, creating, and discovering new possibilities through movement and imagination.
+      Throughout the camp, participants will live together on the Nrityagram campus, sharing the rhythms of village life while learning, creating, and <b>discovering new possibilities through movement, creativity, and imagination</b>. 
     </p>
   </div>
 </div>
 <div class="container accent-bg">
   <div class="wrapper flow">
-    <h1 class="center">Nrityagram Arts in Education Program</h1>
+    <h1 class="center">Nrityagram Arts in Education Programme</h1>
     <div class="image-plus top-flow">
       {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739366286/arts-in-education_dsd40i.png",
       "Children at the Summer Fun for Kids performing at the Odissi gurukul",
@@ -65,13 +73,21 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       <div class="credit" data-image-credit="Courtesy Nrityagram" ></div>
     </div>
     <p>
-			Nrityagram’s Outreach Programme on Sundays, started in 1990 by founder <a href="/protima" class="bodylink">Protima Gauri</a>, is a part of Project Nrityagyān (Dance Education) with a broadened vision to also promote personal growth by developing a strong sense of discipline, high standards of excellence and self-esteem, thus providing children tools to a successful future. 
+      <em>
+        Rooted in the Nrityagram philosophy of learning as a way of life, this programme introduces children to classical dance while nurturing creativity, discipline, and self-confidence.
+      </em>
+    </p>
+    <p>
+			Nrityagram’s <b>Outreach Programme</b>, held every Sunday, was initiated in 1990 by founder <a href="/protima" class="bodylink">Protima Gauri</a> as part of <em>Project Nrityagyān</em> (Dance Education). The programme was envisioned not only as a way to introduce children to classical dance, but also as a means of nurturing personal growth - cultivating discipline, self-confidence, creativity, and a commitment to excellence. 
 		</p>
     <p>
-			Nrityagram’s dancers have developed a method of teaching that is educational, exciting, fun and at the same time uncompromising on excellence and the high standards required to learn classical dance. Our classes are full of energy, passion, commitment, honesty and respect from both sides - teacher and students. This method has helped us to almost instantly win a child's trust because they immediately feel SAFE in class. Children receive honest feedback while knowing that each of them is special, that there are small achievements every day and that they will succeed. And they enthusiastically accept feedback and wholeheartedly put their efforts into new challenges. 
+			Over the years, Nrityagram’s dancers have developed a teaching approach that is rigorous yet joyful. Classes are energetic, engaging, and grounded in the high standards required to learn classical dance. At the same time, they are designed to create an environment where children feel supported, encouraged, and inspired to grow. 
 		</p>
     <p>
-      Our summer camp aspires to heighten this experience for participants by being residential and intensive, as well as multidisciplinary. The simple goals that are the prime focus of this camp are building self-confidence, fostering team spirit, self and group motivation, kindling creative imagination, physical coordination, awareness of rhythms and a sense of music, and nurturing uninhibited expression.
+      A spirit of trust lies at the heart of this approach. Students receive honest feedback while learning to value their own progress, celebrate small achievements, and work steadily toward new challenges. The classroom becomes a space of respect and collaboration, where teachers and students share a commitment to learning.
+    </p>
+    <p>
+      <b>Nrityagram’s Summer Fun for Kids</b> builds on this philosophy. As a residential and multidisciplinary camp, it deepens the experience by immersing participants in a creative community. Through dance, theatre, movement, and shared daily activities, the camp encourages self-confidence, teamwork, imagination, physical coordination, musical awareness, and free, joyful expression.
     </p>
 
   </div>
@@ -80,11 +96,13 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
   <div class="wrapper flow flow-extra">
     <span>
       <h1 class="center">Meet the Camp Mentors</h1>
-      <h4 class="center">Artists and educators guiding creativity, movement, and discovery.</h4>
+      <p class="center">
+        <em>Artists and educators guiding creativity, movement, and discovery.</em>
+      </p>
     </span>
     <p>
-            This year’s Summer Camp is led by a team of experienced educators and performers from the worlds of dance, theatre, and movement, who bring creativity, discipline, and joyful exploration to young learners.
-        </p>
+      This year’s Summer Camp is led by a team of experienced educators and performers from the worlds of dance, theatre, and movement, who bring creativity, discipline, and joyful exploration to young learners.
+    </p>
 
     <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
       <div class="narrow-column">
@@ -98,11 +116,11 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Nivedita Paul</h2>
         <p>Nivedita Paul is an educator and researcher committed to children’s wellbeing, learning, and creative development. She is the founder of <a href="https://p3m.ai" target="_blank" class="bodylink">Pen Pencil Paper and More</a> , an EdTech and empowerment initiative, and has held several leadership and teaching roles in education, including Founding Principal at Ramakrishna Mission School in Kozhikode, Homeroom Tutor at the Aga Khan Academy in Hyderabad, and Teach for India Fellow in Mumbai.</p>
         <p>
-              Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of <a href="/pavithra" class="bodylink">Pavithra Reddy</a>, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
-            </p>
+          Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of <a href="/pavithra" class="bodylink">Pavithra Reddy</a>, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
+        </p>
         <p>
-              She teaches the youngest students in Nrityagram’s outreach programme, bringing together her experience as an educator and her love for dance to introduce children to the beauty and joy of Odissi.
-            </p>
+          She teaches the youngest students in Nrityagram’s outreach programme, bringing together her experience as an educator and her love for dance to introduce children to the beauty and joy of Odissi.
+        </p>
       </div>
     </div>
 
@@ -111,11 +129,11 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Nandakishore K.R.</h2>
         <p>Nandakishore K.R. is a theatre practitioner, lighting designer, mime artist, and movement designer with over three decades of experience in Indian theatre. He has collaborated with many of the country’s most distinguished theatre directors, including B.V. Karanth, Ebrahim Alkazi, Bansi Kaul, Ramgopal Bajaj, C. Basavalingaiah, V. Ramamurthy, and Habib Tanvir.</p>
         <p>
-              An active member of the Kannada amateur theatre movement, he has also worked with artists such as Shankar Nag, Prema Karanth, B. Jayashree, and Suresh Anagalli. His work spans lighting design, directing children’s theatre, visual art collaborations, and film and television, where he has worked as a director, art director, scriptwriter, and producer.
-            </p>
+          An active member of the Kannada amateur theatre movement, he has also worked with artists such as Shankar Nag, Prema Karanth, B. Jayashree, and Suresh Anagalli. His work spans lighting design, directing children’s theatre, visual art collaborations, and film and television, where he has worked as a director, art director, scriptwriter, and producer.
+        </p>
         <p>
-              Associated with Nrityagram since its inception, Nandakishore brings his rich experience in theatre, movement, and storytelling to creative work with young performers.
-            </p>
+          Associated with Nrityagram since its inception, Nandakishore brings his rich experience in theatre, movement, and storytelling to creative work with young performers.
+        </p>
       </div>
       <div class="narrow-column">
         <div class="image-plus">
@@ -167,45 +185,138 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
 </div>
 <div class="container accent-bg">
   <div class="wrapper flow">
-    <h1 class="center">About Kula: Artistes Residence</h1>
+    <h1 class="center">What Children Experience</h1>
     <div class="image-plus top-flow">
-      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
-      "Kula Artistes Residence",
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1773124890/summer-fun-for-kids-2025-3_iup5v6.jpg",
+      "Summer Fun for Kids participants enjoying a nature walk on the Nrityagram campus",
       ["560", "768", "1046"] %}
-      <div class="credit" data-image-credit="Rupert Lorhalder" ></div>
+      <div class="credit" data-image-credit="Courtesy of Nrityagram" ></div>
     </div>
     <p>
-      The participants will stay in our artistes residence - <a href="/kula-artistes-residence" class="bodylink">Kula</a>, which has 8 rooms (2-3 beds per room) with ensuite bathrooms, a common kitchenette (for refreshments and snacks) and a courtyard.
+      At Nrityagram, learning happens not only in the studio but throughout daily life. Participants experience a balance of creative exploration, physical activity, and shared community living.
     </p>
     <p>
-      All the teachers and students of Nrityagram stay within the campus in houses and rooms near Kula and camp participants will be supervised by an adult at all times. All meals and refreshments will be in the common dining area and are primarily vegetarian. 
+      The programme includes:
+      <ul>
+        <li>
+          <b>Odissi Dance</b>
+        </li>
+        <li>
+          <b>Movement and Theatre</b>
+        </li>
+        <li>
+          <b>Aerial Silks</b>
+        </li>
+        <li>
+          <b>Yoga and Body Conditioning</b>
+        </li>
+        <li>
+          <b>Art and Creative Activities</b>
+        </li>
+        <li>
+          <b>Nature Walks and Storytelling</b>
+        </li>
+        <li>
+          <b>Simple Community Activities</b> such as gardening and caring for shared spaces</li>
+      </ul>
     </p>
     <p>
-      In addition to engaging in dance and theatre workshops, camp participants will also be introduced to elements of organic gardening, bird watching and environmental awareness in what is today Bangalore’s only remaining grassland in Hessaraghatta.
+      Together, these experiences nurture creativity, confidence, teamwork, physical coordination, and joyful self-expression.
     </p>
   </div>
 </div>
 <div class="container">
   <div class="wrapper flow">
-    <h1 class="center">Important Notes</h1>
+    <h1 class="center">A Day at Camp</h1>
+    <div class="image-plus top-flow">
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1773126094/summer-fun-for-kids-2025-11_eggaqs.png",
+      "Summer Fun for Kids participants engaging in a creative activity on the Nrityagram campus",
+      ["560", "768", "1046"] %}
+      <div class="credit" data-image-credit="Courtesy of Nrityagram" ></div>
+    </div>
     <p>
-      Careful planning and supervision helps us to provide a safe environment for everyone. Parents must be aware however, that Nrityagram is a rural location and we spend a lot of time outdoors and children will be involved in physical activities including but not limited to their classrooms, climbing trees and outdoor play.
+      Each day at Nrityagram follows a gentle rhythm that balances learning, creativity, and play.
     </p>
     <p>
-      If you have questions or concerns, please email us your phone number and we will return your call. 
+      Participants spend around <b>five hours in guided sessions</b>, divided between dance, theatre, and aerial work, along with yoga and body conditioning. The rest of the day includes nature walks, creative activities, storytelling, and time to relax and enjoy the beauty of the Nrityagram campus.
     </p>
     <p>
-      Email: <a href="mailto:pavithra@nrityagram.org" class="bodylink">pavithra@nrityagram.org</a>
+      In addition to engaging in dance, theatre, and aerial silks, camp participants will also be introduced to bird watching and environmental awareness in what is today Bangalore’s only remaining grassland ecosystem at Hessaraghatta.
+    </p>
+    <p>
+      Children also participate in simple everyday activities such as gardening and caring for shared spaces, becoming part of the Nrityagram community during their stay.
     </p>
   </div>
 </div>
 <div class="container accent-bg">
   <div class="wrapper flow">
-    <h1 class="center">Details</h1>
-    <ul class="extra-margin-top no-bullets">
+    <h1 class="center">Life at Nrityagram</h1>
+    <div class="image-plus top-flow">
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1583857821/6-Kula_fldxvp.jpg",
+      "Kula - the artiste residential area at Nrityagram",
+      ["560", "768", "1046"] %}
+      <div class="credit" data-image-credit="Rupert Lorhaldar" ></div>
+    </div>
+    <p>
+      Located a short distance from Bangalore, <b>Nrityagram Dance Village</b> is a unique community dedicated to the pursuit of classical dance.
+    </p>
+    <p>
+      During the camp, participants live together on the campus, surrounded by flowering trees, birds, and open spaces. In this environment - free from screens and everyday distractions - children experience a mindful way of living where creativity, discipline, and community go hand in hand.
+    </p>
+    <p>
+      The participants will stay in our artistes residence, Kula, which has 8 rooms (2-3 beds per room) with ensuite bathrooms, a common kitchenette (for refreshments and snacks) and a courtyard.
+    </p>
+    <p>
+      All the teachers and students of Nrityagram stay within the campus in houses and rooms near Kula and camp participants will be supervised by an adult at all times. All meals and refreshments will be in the common dining area and are primarily vegetarian.
+    </p>
+  </div>
+</div>
+<div class="container">
+  <div class="wrapper flow">
+    <h1 class="center">Why Parents Love This Camp</h1>
+    <div class="image-plus top-flow">
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1773127241/summer-fun-for-kids-2025-13_jvryhy.png",
+      "Summer Fun for Kids participants enjoying a creative activity and the natural outdoors in the Nrityagram campus",
+      ["560", "768", "1046"] %}
+      <div class="credit" data-image-credit="Courtesy of Nrityagram" ></div>
+    </div>
+    <ul class="no-bullets">
       <li>
-        <b>Age</b>: 7 - 12 years
+        <b>Unique Creative Environment</b>
+        <br>
+        Children spend their days immersed in dance, theatre, and movement within the inspiring surroundings of Nrityagram Dance Village.
       </li>
+      <li>&nbsp;</li>
+      <li>
+        <b>Confidence and Self-Expression</b>
+        <br>
+         Through performance-based learning and creative exploration, children develop confidence, communication skills, and a sense of self.
+      </li>
+      <li>&nbsp;</li>
+      <li>
+        <b>Learning Through Community Living</b>
+        <br>
+        Living together on campus helps children experience cooperation, responsibility, and respect for shared spaces.
+      </li>
+      <li>&nbsp;</li>
+      <li>
+        <b>Connection with Nature</b>
+        <br>
+        Surrounded by trees, birds, and open spaces, participants spend time outdoors and reconnect with the rhythms of the natural world.
+      </li>
+      <li>&nbsp;</li>
+      <li>
+        <b>Joyful Discipline</b>
+        <br>
+        Children experience the balance of structure and play that lies at the heart of the Nrityagram philosophy of learning.
+      </li>
+    </ul>
+  </div>
+</div>
+<div class="container accent-bg">
+  <div class="wrapper flow">
+    <h1 class="center">Practical Details</h1>
+    <ul class="extra-margin-top no-bullets">
       <li>
         <ul class="no-bullets">
           <li>
@@ -220,13 +331,33 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         </ul>
       </li>
       <li>
-        <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
+        <b>Age</b>: 7 - 12 years
+      </li>
+      <li>
+        <ul class="no-bullets">
+          <li>
+            <b>Location</b>: Nrityagram
+          </li>
+          <li>
+            <b>Residential</b>: Yes
+          </li>
+        </ul>
+      </li>
+      <li>
+        <ul class="no-bullets">
+          <li>
+            <b>Number of Participants</b>: Limited places available
+          </li>
+          <li>
+            <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
+          </li>
+        </ul>
       </li>
       <li>
         <b>Enrolment & Payment Terms</b>
         <ul >
           <li>
-            We accept students on a first-come first-served basis, and due to the high level of interest and limited space, we suggest that you sign up immediately, in order to secure a place.
+            We accept students on a first-come first-served basis, and due to the high level of interest and limited space, we suggest that you sign up immediately to secure a place.
           </li>
           <li>
             The full tuition fee must be paid in advance to reserve a place in the Camp. This amount is non-refundable unless we cancel the Camp.
@@ -270,7 +401,12 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <b>Registration</b>: To complete registration, we will provide a link to the registration form that will need to be completed prior to the start of the Camp.
       </li>
       <li>
-        <b>Preparing for the Camp</b>: By mid-March, we will provide detailed information including guidelines, packing list, daily class schedule, etc.
+        <b>Preparing for the Camp</b>: By the second week of April, we will provide detailed information including guidelines, packing list, daily class schedule, etc.
+      </li>
+      <li>
+      If you have questions or concerns, please email us your phone number and we will return your call. 
+      <br />
+      Email: <a href="mailto:pavithra@nrityagram.org" class="bodylink">pavithra@nrityagram.org</a>
       </li>
       <li>
         <b>How to get to Nrityagram</b>: <a href="/findyourway" class="bodylink">Directions</a>

--- a/src/summer-fun-for-kids.njk
+++ b/src/summer-fun-for-kids.njk
@@ -98,7 +98,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Nivedita Paul</h2>
         <p>Nivedita Paul is an educator and researcher committed to children’s wellbeing, learning, and creative development. She is the founder of <a href="https://p3m.ai" target="_blank" class="bodylink">Pen Pencil Paper and More</a> , an EdTech and empowerment initiative, and has held several leadership and teaching roles in education, including Founding Principal at Ramakrishna Mission School in Kozhikode, Homeroom Tutor at the Aga Khan Academy in Hyderabad, and Teach for India Fellow in Mumbai.</p>
         <p>
-              Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of Pavithra Reddy, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
+              Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of <a href="/pavithra" class="bodylink">Pavithra Reddy</a>, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
             </p>
         <p>
               She teaches the youngest students in Nrityagram’s outreach programme, bringing together her experience as an educator and her love for dance to introduce children to the beauty and joy of Odissi.
@@ -106,7 +106,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
       </div>
     </div>
 
-    <div class="uneven-columns wide-grid-gap wide-narrow-60-40">
+    <div class="uneven-columns wide-grid-gap wide-narrow-60-40 reverse-mob">
       <div class="wide-column flow-inbetween">
         <h2>Nandakishore K.R.</h2>
         <p>Nandakishore K.R. is a theatre practitioner, lighting designer, mime artist, and movement designer with over three decades of experience in Indian theatre. He has collaborated with many of the country’s most distinguished theatre directors, including B.V. Karanth, Ebrahim Alkazi, Bansi Kaul, Ramgopal Bajaj, C. Basavalingaiah, V. Ramamurthy, and Habib Tanvir.</p>

--- a/src/summer-fun-for-kids.njk
+++ b/src/summer-fun-for-kids.njk
@@ -176,10 +176,10 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
             <li>
                 <ul class="no-bullets">
                     <li>
-                        <b>Arrival Date</b>: 21 April 2025, 3 - 5pm
+                        <b>Arrival Date</b>: 13 April 2025, 3 - 5pm
           </li>
                     <li>
-                        <b>Departure Date</b>: 26 April 2025, 3 - 5pm
+                        <b>Departure Date</b>: 18 April 2025, 3 - 5pm
           </li>
                     <li>
             The start date is non-negotiable.

--- a/src/summer-fun-for-kids.njk
+++ b/src/summer-fun-for-kids.njk
@@ -11,238 +11,270 @@ description: "Nrityagram’s Summer Fun for Kids is a unique short-term resident
 OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-fun-OG_isgvbz.png"
 ---
 <div id="banner-container">
-    <div class="banner-image">
-        {% pictures 
+  <div class="banner-image">
+    {% pictures 
       {"desk":"https://res.cloudinary.com/nrityagram/image/upload/v1739344263/summer-fun-desk_ljiw54.png", 
       "tab":"https://res.cloudinary.com/nrityagram/image/upload/v1739344263/summer-fun-tablet_ytma9m.png", 
       "mob":"https://res.cloudinary.com/nrityagram/image/upload/v1739344263/summer-fun-mobile_f8o3wu.png"}, 
       "Summer Fun for Kids", 
       {"mob": ["425"], "tab": ["768"], "desk":["1600"]}, {"desk":"65em", "tab":"50em", "mob":"35em"}, 
       "eager", "high" %}
-    </div>
-    <div class="banner-image-credit"
+  </div>
+  <div class="banner-image-credit"
     data-image-credit-desk="Courtesy Nrityagram" 
     data-image-credit-tab="Courtesy Nrityagram" 
     data-image-credit-mob="Courtesy Nrityagram"
     ></div>
-    <div class="banner-title">
+  <div class="banner-title">
         Summer Fun<br />for Kids
   </div>
 </div>
 <div class="container">
-    <div class="wrapper flow">
-        <p>
-			Far from the bustle of Bangalore, the Nrityagram Dance Village houses a group of dancers who have excelled in pursuit of their art. They have performed across the world, won numerous awards and earned global acclaim. According to The New York Times “The only proper response to dancers this amazing is worship!”
-		</p>
-        <p>Who are these dancers, and what do they do all day at Nrityagram?</p>
-        <p>
-      Every year, a small group of children get an opportunity to enrol in Nrityagram’s Summer Fun for Kids to find out for themselves, by leading the Nrityagram life focused on dance and theatre. They explore spaces, go on nature walks, tell stories, play games and most importantly have lots of fun.
+  <div class="wrapper flow">
+    <p>
+			Far from the bustle of Bangalore lies <b>Nrityagram Dance Village</b>, home to a community of dancers who have devoted their lives to the pursuit of their art. The Nrityagram Dance Ensemble has performed across the world, earning international acclaim. As <em>The New York Times said, “The only proper response to dancers this amazing is worship!”</em>
     </p>
-        <p>
-      Nrityagram’s Summer Fun for Kids is a unique short-term residential camp, which brings to participants a compact experience of the Nrityagram philosophy of learning as a way of life.
+    <p>But what is daily life like in this remarkable place?</p>
+    <p>
+      Every year, a small group of children get the opportunity to find out by enrolling in <b>Nrityagram’s Summer Fun for Kids</b>. For a few special days, they experience life at Nrityagram through dance, theatre, storytelling, games, nature walks, and shared community activities.
     </p>
-        <p>
-      Far away from television sets and video games, surrounded by lush foliage, beautiful birds and flowering trees, they experience life in a place where all residents take care of themselves and their “home" and where the entire community lives mindfully. The camp also gives children a glimpse into the guru-shishya parampara followed at Nrityagram, while they are led through dance and theatre sessions.
+    <p>
+      <b>Summer Fun for Kids</b> is a unique short-term residential camp that offers participants a glimpse into the Nrityagram philosophy - where learning is not confined to a classroom, but lived as a way of life. Away from television screens and video games, and surrounded by flowering trees, birds, and open spaces, children experience a rhythm of living where everyone cares for themselves, their surroundings, and their shared home.
     </p>
-        <p>
-      Camp participants follow a five-hour daily learning schedule, with theatre and dance in two separate batches, in addition to engaging in and learning simple day-to-day activities such as cleaning, cooking and gardening. They also participate in yoga and body conditioning classes, in addition to fun sessions in art. Most of the children (and their parents) describe the experience as ‘life changing’.
+    <p>
+      The camp also introduces children to the spirit of the <b>guru-shishya parampara</b> that guides learning at Nrityagram. Participants follow a five-hour daily learning schedule that includes dance and theatre sessions, along with yoga, body conditioning, and creative art activities. They also take part in simple everyday tasks such as cooking, gardening, and caring for the campus - becoming part of the community for the duration of the camp. Many children (and their parents) later describe the experience as truly life-changing.
     </p>
-        <p>
-      The two basic components of the camp are dance and theatre. One of India’s best known Odissi Dancers <a href="/pavithra" class="bodylink">Pavithra Reddy</a>, a <a href="/ensemble" class="bodylink">Nrityagram Ensemble</a> and faculty member, will lead the sessions in Odissi dance.
+    <p>
+      Dance and theatre have always been the core elements of the camp. This year, we are excited to introduce a new addition: <b>Aerial Silk Work</b>.
     </p>
-        <p>
-      This year we have invited Shruti Jasani to teach theatre and Yoga classes. Shruti leads the faculty at The Wooden Stage, a performance arts institute in Mumbai teaching aerial art to over 400 students.
+    <p>
+      The camp will be led by a team of experienced artists and educators. <b>Nivedita Paul</b>, a Nrityagram dancer and educator, will guide the Odissi dance sessions. <b>Nandakishore K.R.</b>, a theatre practitioner and long-time collaborator of Nrityagram, will lead movement and theatre classes. <b>Shruti Jasani</b>, performer and founder of The Wooden Stage in Mumbai, will conduct sessions in Aerial Silk Movement and Body Conditioning.
     </p>
-        <p>
-      Everyone will live at the Nrityagram campus.
+    <p>
+      Throughout the camp, participants will live together on the Nrityagram campus, sharing the rhythms of village life while learning, creating, and discovering new possibilities through movement and imagination.
     </p>
-    </div>
+  </div>
 </div>
 <div class="container accent-bg">
-    <div class="wrapper flow">
-        <h1 class="center">Nrityagram Arts in Education Program</h1>
-        <div class="image-plus top-flow">
-            {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739366286/arts-in-education_dsd40i.png",
+  <div class="wrapper flow">
+    <h1 class="center">Nrityagram Arts in Education Program</h1>
+    <div class="image-plus top-flow">
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739366286/arts-in-education_dsd40i.png",
       "Children at the Summer Fun for Kids performing at the Odissi gurukul",
       ["560", "768", "1046"] %}
-            <div class="credit" data-image-credit="Courtesy Nrityagram" ></div>
-        </div>
-        <p>
+      <div class="credit" data-image-credit="Courtesy Nrityagram" ></div>
+    </div>
+    <p>
 			Nrityagram’s Outreach Programme on Sundays, started in 1990 by founder <a href="/protima" class="bodylink">Protima Gauri</a>, is a part of Project Nrityagyān (Dance Education) with a broadened vision to also promote personal growth by developing a strong sense of discipline, high standards of excellence and self-esteem, thus providing children tools to a successful future. 
 		</p>
-        <p>
+    <p>
 			Nrityagram’s dancers have developed a method of teaching that is educational, exciting, fun and at the same time uncompromising on excellence and the high standards required to learn classical dance. Our classes are full of energy, passion, commitment, honesty and respect from both sides - teacher and students. This method has helped us to almost instantly win a child's trust because they immediately feel SAFE in class. Children receive honest feedback while knowing that each of them is special, that there are small achievements every day and that they will succeed. And they enthusiastically accept feedback and wholeheartedly put their efforts into new challenges. 
 		</p>
-        <p>
+    <p>
       Our summer camp aspires to heighten this experience for participants by being residential and intensive, as well as multidisciplinary. The simple goals that are the prime focus of this camp are building self-confidence, fostering team spirit, self and group motivation, kindling creative imagination, physical coordination, awareness of rhythms and a sense of music, and nurturing uninhibited expression.
     </p>
 
-    </div>
+  </div>
 </div>
 <div class="container">
-    <div class="wrapper flow flow-extra">
-        <h1 class="center">The Teachers</h1>
-        <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
-            <div class="narrow-column">
-                <div class="image-plus">
-                    {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739366969/shruti_jasani_fadvlv.jpg",
-                    "Shruti Jasani",
-                    ["auto", "425"] %}
-                </div>
-            </div>
-            <div class="wide-column flow-inbetween">
-                <h2>Shruti Jasani</h2>
-                <p>
-          Shruti studied contemporary dance and ballet at The New York University, and has also been affiliated with the Trinity College of London since 2005 where she specialised in the Performance Arts syllabus, taking professional level exams and also teaching dance and drama under the same roof. She has also studied at Aerial Arts New York, and Womack and Bowman, This wealth of knowledge, while great on paper, really shines through when you experience an aerial class at The Wooden Stage, taught by Shruti.
+  <div class="wrapper flow flow-extra">
+    <span>
+      <h1 class="center">Meet the Camp Mentors</h1>
+      <h4 class="center">Artists and educators guiding creativity, movement, and discovery.</h4>
+    </span>
+    <p>
+            This year’s Summer Camp is led by a team of experienced educators and performers from the worlds of dance, theatre, and movement, who bring creativity, discipline, and joyful exploration to young learners.
         </p>
-                <p>
-          In addition to co-founding a successful studio (TWC) where she quite literally “hangs” with grown-up and child students who can’t wait for class o’ clock, Shruti has also taken her aerial skills to the silver screen.
-        </p>
-                <p>
-          Shruti has also been invited to showcase her skills at TedX, besides speaking and performing at Tiecon and doing theatre performances. She plays KAA the python in Jungle Book part 2 Musical.
-        </p>
-            </div>
 
-        </div>
-
-        <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
-            <div class="narrow-column">
-                <div class="image-plus">
-                    {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739369921/pavi-reddy-summer-fun_moh4q7.png",
-          "Pavithra Reddy",
+    <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
+      <div class="narrow-column">
+        <div class="image-plus">
+          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1772776099/Nivedita_qdnhhc.jpg",
+          "Nivedita Paul",
           ["auto", "425"] %}
-                </div>
-            </div>
-            <div class="wide-column flow-inbetween">
-                <h2>Pavithra Reddy</h2>
-                <p>
-          Pavithra lives at a neighbouring farm and started her Odissi training in Nrityagram’s rural outreach programme in 1990. She was the first student to graduate from Nrityagram’s rural outreach programme.
-        </p>
-                <p>
-          She learned Odissi under the tutelage of <a href="/surupa" class="bodylink">Surupa Sen</a> and has worked with dancers and movement specialists from across the globe.
-        </p>
-                <p>
-          Pavithra joined the Nrityagram Dance Ensemble 1993 and has performed solo and with the Ensemble at some of the most prestigious venues across India and the world.
-        </p>
-                <p>
-          In addition to being a full-time performer, Pavithra teaches in Nrityagram’s residential and outreach programs and is the Director of Outreach Activities.
-        </p>
-            </div>
         </div>
-
+      </div>
+      <div class="wide-column flow-inbetween">
+        <h2>Nivedita Paul</h2>
+        <p>Nivedita Paul is an educator and researcher committed to children’s wellbeing, learning, and creative development. She is the founder of <a href="https://p3m.ai" target="_blank" class="bodylink">Pen Pencil Paper and More</a> , an EdTech and empowerment initiative, and has held several leadership and teaching roles in education, including Founding Principal at Ramakrishna Mission School in Kozhikode, Homeroom Tutor at the Aga Khan Academy in Hyderabad, and Teach for India Fellow in Mumbai.</p>
+        <p>
+              Nivedita began her training in Odissi after attending a Summer Workshop at Nrityagram in 2018. She has since continued her studies under the guidance of Pavithra Reddy, first through online classes and, since 2022, as a Day Scholar at Nrityagram.
+            </p>
+        <p>
+              She teaches the youngest students in Nrityagram’s outreach programme, bringing together her experience as an educator and her love for dance to introduce children to the beauty and joy of Odissi.
+            </p>
+      </div>
     </div>
+
+    <div class="uneven-columns wide-grid-gap wide-narrow-60-40">
+      <div class="wide-column flow-inbetween">
+        <h2>Nandakishore K.R.</h2>
+        <p>Nandakishore K.R. is a theatre practitioner, lighting designer, mime artist, and movement designer with over three decades of experience in Indian theatre. He has collaborated with many of the country’s most distinguished theatre directors, including B.V. Karanth, Ebrahim Alkazi, Bansi Kaul, Ramgopal Bajaj, C. Basavalingaiah, V. Ramamurthy, and Habib Tanvir.</p>
+        <p>
+              An active member of the Kannada amateur theatre movement, he has also worked with artists such as Shankar Nag, Prema Karanth, B. Jayashree, and Suresh Anagalli. His work spans lighting design, directing children’s theatre, visual art collaborations, and film and television, where he has worked as a director, art director, scriptwriter, and producer.
+            </p>
+        <p>
+              Associated with Nrityagram since its inception, Nandakishore brings his rich experience in theatre, movement, and storytelling to creative work with young performers.
+            </p>
+      </div>
+      <div class="narrow-column">
+        <div class="image-plus">
+          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1772776107/Kishore_kkvqys.jpg",
+          "Nandakishore K.R.",
+          ["auto", "425"] %}
+        </div>
+      </div>
+    </div>
+
+    <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
+      <div class="narrow-column">
+        <div class="image-plus">
+          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739366969/shruti_jasani_fadvlv.jpg",
+          "Shruti Jasani",
+          ["auto", "425"] %}
+        </div>
+      </div>
+      <div class="wide-column flow-inbetween">
+        <h2>Shruti Jasani</h2>
+        <p>Shruti Jasani is a performer and movement teacher whose work spans contemporary dance, ballet, theatre, and aerial arts. She studied contemporary dance and ballet at New York University and has been affiliated with Trinity College London since 2005, where she specialised in the Performing Arts syllabus, completing professional examinations and teaching dance and drama.</p>
+        <p>She has also trained at Aerial Arts New York and with Womack and Bowman, and is the co-founder of The Wooden Stage, a studio where she teaches aerial arts to both children and adults. In addition to teaching, Shruti has performed widely in theatre and public events, including appearances at TEDx and TiEcon, and currently plays Kaa the python in the musical production The Jungle Book – Part 2.</p>
+        <p>At the Summer Camp, Shruti will lead sessions in Aerial Silk Movement and Body Conditioning, inviting young participants to experience strength, balance, and imagination in motion.</p>
+      </div>
+    </div>
+
+    <!-- <div class="uneven-columns wide-grid-gap narrow-wide-40-60">
+          <div class="narrow-column">
+              <div class="image-plus">
+                  {% image "https://res.cloudinary.com/nrityagram/image/upload/v1739369921/pavi-reddy-summer-fun_moh4q7.png", "Pavithra Reddy", ["auto", "425"] %}
+              </div>
+          </div>
+          <div class="wide-column flow-inbetween">
+            <h2>Pavithra Reddy</h2>
+            <p>Pavithra lives at a neighbouring farm and started her Odissi training in Nrityagram’s rural outreach programme in 1990. She was the first student to graduate from Nrityagram’s rural outreach programme.
+            </p>
+            <p>She learned Odissi under the tutelage of <a href="/surupa" class="bodylink">Surupa Sen</a> and has worked with dancers and movement specialists from across the globe.
+            </p>
+            <p>
+            Pavithra joined the Nrityagram Dance Ensemble 1993 and has performed solo and with the Ensemble at some of the most prestigious venues across India and the world.
+            </p>
+            <p>
+            In addition to being a full-time performer, Pavithra teaches in Nrityagram’s residential and outreach programs and is the Director of Outreach Activities.
+            </p>
+          </div>
+        </div> -->
+
+  </div>
 </div>
 <div class="container accent-bg">
-    <div class="wrapper flow">
-        <h1 class="center">About Kula: Artistes Residence</h1>
-        <div class="image-plus top-flow">
-            {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
+  <div class="wrapper flow">
+    <h1 class="center">About Kula: Artistes Residence</h1>
+    <div class="image-plus top-flow">
+      {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
       "Kula Artistes Residence",
       ["560", "768", "1046"] %}
-            <div class="credit" data-image-credit="Rupert Lorhalder" ></div>
-        </div>
-        <p>
+      <div class="credit" data-image-credit="Rupert Lorhalder" ></div>
+    </div>
+    <p>
       The participants will stay in our artistes residence - <a href="/kula-artistes-residence" class="bodylink">Kula</a>, which has 8 rooms (2-3 beds per room) with ensuite bathrooms, a common kitchenette (for refreshments and snacks) and a courtyard.
     </p>
-        <p>
+    <p>
       All the teachers and students of Nrityagram stay within the campus in houses and rooms near Kula and camp participants will be supervised by an adult at all times. All meals and refreshments will be in the common dining area and are primarily vegetarian. 
     </p>
-        <p>
+    <p>
       In addition to engaging in dance and theatre workshops, camp participants will also be introduced to elements of organic gardening, bird watching and environmental awareness in what is today Bangalore’s only remaining grassland in Hessaraghatta.
     </p>
-    </div>
+  </div>
 </div>
 <div class="container">
-    <div class="wrapper flow">
-        <h1 class="center">Important Notes</h1>
-        <p>
+  <div class="wrapper flow">
+    <h1 class="center">Important Notes</h1>
+    <p>
       Careful planning and supervision helps us to provide a safe environment for everyone. Parents must be aware however, that Nrityagram is a rural location and we spend a lot of time outdoors and children will be involved in physical activities including but not limited to their classrooms, climbing trees and outdoor play.
     </p>
-        <p>
+    <p>
       If you have questions or concerns, please email us your phone number and we will return your call. 
     </p>
-        <p>
+    <p>
       Email: <a href="mailto:pavithra@nrityagram.org" class="bodylink">pavithra@nrityagram.org</a>
-        </p>
-    </div>
+    </p>
+  </div>
 </div>
 <div class="container accent-bg">
-    <div class="wrapper flow">
-        <h1 class="center">Details</h1>
-        <ul class="extra-margin-top no-bullets">
-            <li>
-                <b>Age</b>: 7 - 12 years
+  <div class="wrapper flow">
+    <h1 class="center">Details</h1>
+    <ul class="extra-margin-top no-bullets">
+      <li>
+        <b>Age</b>: 7 - 12 years
       </li>
-            <li>
-                <ul class="no-bullets">
-                    <li>
-                        <b>Arrival Date</b>: 13 April 2025, 3 - 5pm
+      <li>
+        <ul class="no-bullets">
+          <li>
+            <b>Arrival Date</b>: 28th April 2026, 3 - 5pm
           </li>
-                    <li>
-                        <b>Departure Date</b>: 18 April 2025, 3 - 5pm
+          <li>
+            <b>Departure Date</b>: 3rd May 2026, 3 - 5pm
           </li>
-                    <li>
+          <li>
             The start date is non-negotiable.
           </li>
-                </ul>
-            </li>
-            <li>
-                <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
+        </ul>
       </li>
-            <li>
-                <b>Enrolment & Payment Terms</b>
-                <ul >
-                    <li>
+      <li>
+        <b>Fee:</b> ₹20,000 + ₹300 Convenience Fee (Subject to change.)
+      </li>
+      <li>
+        <b>Enrolment & Payment Terms</b>
+        <ul >
+          <li>
             We accept students on a first-come first-served basis, and due to the high level of interest and limited space, we suggest that you sign up immediately, in order to secure a place.
           </li>
-                    <li>
+          <li>
             The full tuition fee must be paid in advance to reserve a place in the Camp. This amount is non-refundable unless we cancel the Camp.
           </li>
-                    <li>
+          <li>
             Upon receipt of the tuition fee, you will receive a confirmation of payment. Please check your Spam Folder in case it ends up there.
           </li>
-                </ul>
-            </li>
         </ul>
+      </li>
+    </ul>
 
-        <div class="razorpay-embed-btn center"
-                 data-url="https://pages.razorpay.com/pl_Pury7q2u6R7N7j/view"
-                 data-text="ALL SEATS BOOKED"
-                 data-color="#a5a5a5"
-                 disabled
-                 aria-disabled="true"
+    <!-- data-text="ALL SEATS BOOKED" data-color="#a5a5a5" disabled aria-disabled="true"-->
+    <div class="razorpay-embed-btn center"
+                 data-url="https://rzp.io/rzp/summer-fun-2026"
+                 data-text="Pay Registration Fee"
+                 data-color="#C91D25"
                  data-size="large">
 
-            <script>
-                (function () {
-                    var d = document;
-                    var x = !d.getElementById('razorpay-embed-btn-js')
-                    if (x) {
-                        var s = d.createElement('script');
-                        s.defer = !0;
-                        s.id = 'razorpay-embed-btn-js';
-                        s.src = 'https://cdn.razorpay.com/static/embed_btn/bundle.js';
-                        d
-                            .body
-                            .appendChild(s);
-                    } else {
-                        var rzp = window['__rzp__'];
-                        rzp && rzp.init && rzp.init()
-                    }
-                })();
-            </script>
-        </div>
-
-        <ul class="extra-margin-top no-bullets">
-            <li>
-                <b>Registration</b>: To complete registration, we will provide a link to the registration form that will need to be completed prior to the start of the Camp.
-      </li>
-            <li>
-                <b>Preparing for the Camp</b>: By mid-March, we will provide detailed information including guidelines, packing list, daily class schedule, etc.
-      </li>
-            <li>
-                <b>How to get to Nrityagram</b>: <a href="/findyourway" class="bodylink">Directions</a>
-            </li>
-        </ul>
+      <script>
+        (function () {
+          var d = document;
+          var x = !d.getElementById('razorpay-embed-btn-js')
+          if (x) {
+            var s = d.createElement('script');
+            s.defer = !0;
+            s.id = 'razorpay-embed-btn-js';
+            s.src = 'https://cdn.razorpay.com/static/embed_btn/bundle.js';
+            d
+              .body
+              .appendChild(s);
+          } else {
+            var rzp = window['__rzp__'];
+            rzp && rzp.init && rzp.init()
+          }
+        })();
+      </script>
     </div>
+
+    <ul class="extra-margin-top no-bullets">
+      <li>
+        <b>Registration</b>: To complete registration, we will provide a link to the registration form that will need to be completed prior to the start of the Camp.
+      </li>
+      <li>
+        <b>Preparing for the Camp</b>: By mid-March, we will provide detailed information including guidelines, packing list, daily class schedule, etc.
+      </li>
+      <li>
+        <b>How to get to Nrityagram</b>: <a href="/findyourway" class="bodylink">Directions</a>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/src/summer-workshop.njk
+++ b/src/summer-workshop.njk
@@ -9,6 +9,7 @@ title: "Summer Workshop"
 scrollToTop: true
 description: "Summer Workshop is a unique short-term programme in Odissi basics as developed and practised at Nrityagram, which also brings to students a compact experience of our philosophy of practising art as a way of life."
 OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1743082932/summer-workshop-og_ptykjy.png"
+archive: true
 ---
 <div id="banner-container">
     <div class="banner-image">


### PR DESCRIPTION
Full content rehaul, pictures, razorpay payment page link for 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page archival flag implemented; archived pages are excluded from sitemap and robots rules.

* **Updates**
  * Summer Fun for Kids promoted sitewide with 28 Apr–3 May 2026 dates and "Registrations Open" CTAs on desktop and mobile.
  * Full refresh of the Summer Fun for Kids page: content, mentors, schedule, logistics, and registration flow updated.
  * Donation page EIN presentation improved for better browser rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->