### PR TITLE
Update: Added a line in Shruti's bio

### DIFF
--- a/src/summer-fun-for-kids.njk
+++ b/src/summer-fun-for-kids.njk
@@ -156,6 +156,9 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/v1739344539/summer-
         <h2>Shruti Jasani</h2>
         <p>Shruti Jasani is a performer and movement teacher whose work spans contemporary dance, ballet, theatre, and aerial arts. She studied contemporary dance and ballet at New York University and has been affiliated with Trinity College London since 2005, where she specialised in the Performing Arts syllabus, completing professional examinations and teaching dance and drama.</p>
         <p>She has also trained at Aerial Arts New York and with Womack and Bowman, and is the co-founder of <a href="https://thewoodenstage.com/" target="_blank" class="bodylink">The Wooden Stage</a>, a studio where she teaches aerial arts to both children and adults. In addition to teaching, Shruti has performed widely in theatre and public events, including appearances at TEDx and TiEcon, and currently plays Kaa the python in the musical production The Jungle Book – Part 2.</p>
+        <p>
+          Shruti first came to Nrityagram for a Summer Workshop in 2022 and continues Odissi training through bi-weekly online classes and short-term residential workshops.
+        </p>
         <p>At the Summer Camp, Shruti will lead sessions in Aerial Silk Movement and Body Conditioning, inviting young participants to experience strength, balance, and imagination in motion.</p>
       </div>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bio section with additional details about Shruti Jasani's training background, including information about her Nrityagram Summer Workshop participation and ongoing Odissi dance training through online classes and residential workshops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->