### PR TITLE
Add Vihāra dance residency card to community pages

### DIFF
--- a/netlify/functions/preview/src/board.njk
+++ b/netlify/functions/preview/src/board.njk
@@ -250,7 +250,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1569995939/b
         </div>
         <div class="text-card flow-inbetween">
           <p>
-            Sridhar Mahadevan seeks to understand the fundamental principles of the universe, be it in terms of underlying order or manifest expression. Fueled by his curiosity about how the universe works, he opted for a dual degree course that combined electrical engineering and a post-graduate program in physics at BITS Pilani. He went on to become a Co-Founder and Chief Operating Officer of iLink Systems, which is a multi-million dollar software services firm, headquartered in Redmond, WA, USA.
+            Sridhar Mahadevan seeks to understand the fundamental principles of the universe, be it in terms of underlying order or manifest expression. Fueled by his curiosity about how the universe works, he opted for a dual degree course that combined electrical engineering and a post-graduate program in physics at BITS Pilani.
           </p>
           <p>
             He was introduced to dance by his mother, a Bharatanatyam practitioner. As an adult, he underwent formal training in Bharatanatyam and Kalaripayattu. He became an ardent rasika, attending as many dance concerts as he could, and voraciously read on theory and dance forms across the world.
@@ -321,7 +321,7 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1569995939/b
       </div>
       <div class="text-card flow-inbetween" id="trustee5-bio">
         <p>
-          Sridhar Mahadevan seeks to understand the fundamental principles of the universe, be it in terms of underlying order or manifest expression. Fueled by his curiosity about how the universe works, he opted for a dual degree course that combined electrical engineering and a post-graduate program in physics at BITS Pilani. He went on to become a Co-Founder and Chief Operating Officer of iLink Systems, which is a multi-million dollar software services firm, headquartered in Redmond, WA, USA.
+          Sridhar Mahadevan seeks to understand the fundamental principles of the universe, be it in terms of underlying order or manifest expression. Fueled by his curiosity about how the universe works, he opted for a dual degree course that combined electrical engineering and a post-graduate program in physics at BITS Pilani.
         </p>
         <p>
           He was introduced to dance by his mother, a Bharatanatyam practitioner. As an adult, he underwent formal training in Bharatanatyam and Kalaripayattu. He became an ardent rasika, attending as many dance concerts as he could, and voraciously read on theory and dance forms across the world.

--- a/netlify/functions/preview/src/building-a-dance-community.njk
+++ b/netlify/functions/preview/src/building-a-dance-community.njk
@@ -191,28 +191,38 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1718616963/d
         </div>
       </div>
     </div>
-    <div class="even-columns">
-      <div class="left-column">
-        <div class="image-plus card" onclick="location.href='/popularising-the-arts';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718613522/ajji-masthead-desk_uzyz4t.png",
-          "Popularising the Arts Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Pavithra Reddy" ></div>
-          <div class="card-title">Popularising<br />the Arts</div>
+    <div class="even-columns-unlimited">
+
+      <div class="image-plus card size-md" onclick="location.href='/popularising-the-arts';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718613522/ajji-masthead-desk_uzyz4t.png",
+        "Popularising the Arts Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Pavithra Reddy" ></div>
+        <div class="card-title">Popularising<br />the Arts</div>
+      </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/kula-artistes-residence';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
+        "Kula: Artistes’ Residence Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Rupert Lorhaldar" ></div>
+        <div class="card-title">
+          Kula
+          <div class="sub-title">Artistes’ Residence</div>
         </div>
       </div>
-      <div class="right-column">
-        <div class="image-plus card" onclick="location.href='/kula-artistes-residence';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
-          "Kula: Artistes’ Residence Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Rupert Lorhaldar" ></div>
-          <div class="card-title">
-            Kula
-            <div class="sub-title">Artistes’ Residence</div>
-          </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/dance-residency';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1777342463/dance-residency-masthead-desk_hfr21e.png",
+        "Vihāra: Dance Residency Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Anoushka Rahman" ></div>
+        <div class="card-title">
+          Vihāra
+          <div class="sub-title">Dance Residency</div>
         </div>
       </div>
+
     </div>
   </div>
 </div>

--- a/netlify/functions/preview/src/community.njk
+++ b/netlify/functions/preview/src/community.njk
@@ -111,31 +111,41 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/a_hflip/v1646
         </div>
       </div>
     </div>
-    <div class="even-columns">
-      <div class="left-column">
-        <div class="image-plus card" onclick="location.href='/kula-artistes-residence';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
-          "Kula: Artistes’ Residence Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Unknown" ></div>
-          <div class="card-title">
-            Kula
-            <div class="sub-title">Artistes’ Residence</div>
-          </div>
+    <div class="even-columns-unlimited">
+
+      <div class="image-plus card size-md" onclick="location.href='/kula-artistes-residence';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
+        "Kula: Artistes’ Residence Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Unknown" ></div>
+        <div class="card-title">
+          Kula
+          <div class="sub-title">Artistes’ Residence</div>
         </div>
       </div>
-      <div class="right-column">
-        <div class="image-plus card" onclick="location.href='/building-a-dance-community';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
-          "Building a Dance Community Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Ravi Shankar" ></div>
-          <div class="card-title">
-            Dance Commons
-            <div class="sub-title">Building a Dance Community</div>
-          </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/building-a-dance-community';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
+        "Building a Dance Community Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Ravi Shankar" ></div>
+        <div class="card-title">
+          Dance Commons
+          <div class="sub-title">Building a Dance Community</div>
         </div>
       </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/dance-residency';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1777342463/dance-residency-masthead-desk_hfr21e.png",
+        "Vihāra: Dance Residency Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Anoushka Rahman" ></div>
+        <div class="card-title">
+          Vihāra
+          <div class="sub-title">Dance Residency</div>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/netlify/functions/preview/src/ensemble.njk
+++ b/netlify/functions/preview/src/ensemble.njk
@@ -68,10 +68,10 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1569697661/e
 				</p>
         <p class="infotext">
 				Exclusive US Representation<br />
-				PENTACLE<br />
+				Cía Artists Management<br />
         Sandy Garcia<br />
-          <a href="mailto:sandyg@pentacle.org" target="_blank" class="bodylink">sandyg@pentacle.org</a><br />
-          <a href="https://www.pentacle.org" target="_blank" class="bodylink">www.pentacle.org</a>
+          <a href="mailto:sandy@ciaartists.com" target="_blank" class="bodylink">sandy@ciaartists.com</a><br />
+          <a href="https://www.ciaartists.com/" target="_blank" class="bodylink">www.ciaartists.com</a>
         </p>
       </div>
       <div class="spacer-column"></div>

--- a/netlify/functions/preview/src/kula-artistes-residence.njk
+++ b/netlify/functions/preview/src/kula-artistes-residence.njk
@@ -124,28 +124,38 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1719899818/K
         </div>
       </div>
     </div>
-    <div class="even-columns">
-      <div class="left-column">
-        <div class="image-plus card" onclick="location.href='/popularising-the-arts';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718613522/ajji-masthead-desk_uzyz4t.png",
-          "Popularising the Arts Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Pavithra Reddy" ></div>
-          <div class="card-title">Popularising<br />the Arts</div>
+    <div class="even-columns-unlimited">
+
+      <div class="image-plus card size-md" onclick="location.href='/popularising-the-arts';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718613522/ajji-masthead-desk_uzyz4t.png",
+        "Popularising the Arts Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Pavithra Reddy" ></div>
+        <div class="card-title">Popularising<br />the Arts</div>
+      </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/building-a-dance-community';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
+        "Building a Dance Community Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Ravi Shankar" ></div>
+        <div class="card-title">
+          Dance Commons
+          <div class="sub-title">Building a Dance Community</div>
         </div>
       </div>
-      <div class="right-column">
-        <div class="image-plus card" onclick="location.href='/building-a-dance-community';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
-          "Building a Dance Community Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Ravi Shankar" ></div>
-          <div class="card-title">
-            Dance Commons
-            <div class="sub-title">Building a Dance Community</div>
-          </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/dance-residency';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1777342463/dance-residency-masthead-desk_hfr21e.png",
+        "Vihāra: Dance Residency Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Anoushka Rahman" ></div>
+        <div class="card-title">
+          Vihāra
+          <div class="sub-title">Dance Residency</div>
         </div>
       </div>
+
     </div>
   </div>
 </div>

--- a/netlify/functions/preview/src/popularising-the-arts.njk
+++ b/netlify/functions/preview/src/popularising-the-arts.njk
@@ -484,31 +484,41 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1726534956/p
         </div>
       </div>
     </div>
-    <div class="even-columns">
-      <div class="left-column">
-        <div class="image-plus card" onclick="location.href='/kula-artistes-residence';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
-          "Kula: Artistes’ Residence Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Unknown" ></div>
-          <div class="card-title">
-            Kula
-            <div class="sub-title">Artistes’ Residence</div>
-          </div>
+    <div class="even-columns-unlimited">
+
+      <div class="image-plus card size-md" onclick="location.href='/kula-artistes-residence';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
+        "Kula: Artistes’ Residence Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Unknown" ></div>
+        <div class="card-title">
+          Kula
+          <div class="sub-title">Artistes’ Residence</div>
         </div>
       </div>
-      <div class="right-column">
-        <div class="image-plus card" onclick="location.href='/building-a-dance-community';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
-          "Building a Dance Community Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Ravi Shankar" ></div>
-          <div class="card-title">
-            Dance Commons
-            <div class="sub-title">Building a Dance Community</div>
-          </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/building-a-dance-community';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
+        "Building a Dance Community Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Ravi Shankar" ></div>
+        <div class="card-title">
+          Dance Commons
+          <div class="sub-title">Building a Dance Community</div>
         </div>
       </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/dance-residency';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1777342463/dance-residency-masthead-desk_hfr21e.png",
+        "Vihāra: Dance Residency Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Anoushka Rahman" ></div>
+        <div class="card-title">
+          Vihāra
+          <div class="sub-title">Dance Residency</div>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/netlify/functions/preview/src/village-outreach.njk
+++ b/netlify/functions/preview/src/village-outreach.njk
@@ -120,31 +120,41 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1569846362/v
         </div>
       </div>
     </div>
-    <div class="even-columns">
-      <div class="left-column">
-        <div class="image-plus card" onclick="location.href='/kula-artistes-residence';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
-          "Kula: Artistes’ Residence Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Unknown" ></div>
-          <div class="card-title">
-            Kula
-            <div class="sub-title">Artistes’ Residence</div>
-          </div>
+    <div class="even-columns-unlimited">
+
+      <div class="image-plus card size-md" onclick="location.href='/kula-artistes-residence';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
+        "Kula: Artistes’ Residence Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Unknown" ></div>
+        <div class="card-title">
+          Kula
+          <div class="sub-title">Artistes’ Residence</div>
         </div>
       </div>
-      <div class="right-column">
-        <div class="image-plus card" onclick="location.href='/building-a-dance-community';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
-          "Building a Dance Community Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Ravi Shankar" ></div>
-          <div class="card-title">
-            Dance Commons
-            <div class="sub-title">Building a Dance Community</div>
-          </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/building-a-dance-community';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
+        "Building a Dance Community Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Ravi Shankar" ></div>
+        <div class="card-title">
+          Dance Commons
+          <div class="sub-title">Building a Dance Community</div>
         </div>
       </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/dance-residency';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1777342463/dance-residency-masthead-desk_hfr21e.png",
+        "Vihāra: Dance Residency Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Anoushka Rahman" ></div>
+        <div class="card-title">
+          Vihāra
+          <div class="sub-title">Dance Residency</div>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/src/building-a-dance-community.njk
+++ b/src/building-a-dance-community.njk
@@ -191,28 +191,38 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1718616963/d
         </div>
       </div>
     </div>
-    <div class="even-columns">
-      <div class="left-column">
-        <div class="image-plus card" onclick="location.href='/popularising-the-arts';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718613522/ajji-masthead-desk_uzyz4t.png",
-          "Popularising the Arts Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Pavithra Reddy" ></div>
-          <div class="card-title">Popularising<br />the Arts</div>
+    <div class="even-columns-unlimited">
+
+      <div class="image-plus card size-md" onclick="location.href='/popularising-the-arts';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718613522/ajji-masthead-desk_uzyz4t.png",
+        "Popularising the Arts Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Pavithra Reddy" ></div>
+        <div class="card-title">Popularising<br />the Arts</div>
+      </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/kula-artistes-residence';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
+        "Kula: Artistes’ Residence Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Rupert Lorhaldar" ></div>
+        <div class="card-title">
+          Kula
+          <div class="sub-title">Artistes’ Residence</div>
         </div>
       </div>
-      <div class="right-column">
-        <div class="image-plus card" onclick="location.href='/kula-artistes-residence';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
-          "Kula: Artistes’ Residence Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Rupert Lorhaldar" ></div>
-          <div class="card-title">
-            Kula
-            <div class="sub-title">Artistes’ Residence</div>
-          </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/dance-residency';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1777342463/dance-residency-masthead-desk_hfr21e.png",
+        "Vihāra: Dance Residency Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Anoushka Rahman" ></div>
+        <div class="card-title">
+          Vihāra
+          <div class="sub-title">Dance Residency</div>
         </div>
       </div>
+
     </div>
   </div>
 </div>

--- a/src/community.njk
+++ b/src/community.njk
@@ -111,31 +111,41 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/a_hflip/v1646
         </div>
       </div>
     </div>
-    <div class="even-columns">
-      <div class="left-column">
-        <div class="image-plus card" onclick="location.href='/kula-artistes-residence';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
-          "Kula: Artistes’ Residence Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Unknown" ></div>
-          <div class="card-title">
-            Kula
-            <div class="sub-title">Artistes’ Residence</div>
-          </div>
+    <div class="even-columns-unlimited">
+
+      <div class="image-plus card size-md" onclick="location.href='/kula-artistes-residence';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
+        "Kula: Artistes’ Residence Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Unknown" ></div>
+        <div class="card-title">
+          Kula
+          <div class="sub-title">Artistes’ Residence</div>
         </div>
       </div>
-      <div class="right-column">
-        <div class="image-plus card" onclick="location.href='/building-a-dance-community';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
-          "Building a Dance Community Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Ravi Shankar" ></div>
-          <div class="card-title">
-            Dance Commons
-            <div class="sub-title">Building a Dance Community</div>
-          </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/building-a-dance-community';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
+        "Building a Dance Community Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Ravi Shankar" ></div>
+        <div class="card-title">
+          Dance Commons
+          <div class="sub-title">Building a Dance Community</div>
         </div>
       </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/dance-residency';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1777342463/dance-residency-masthead-desk_hfr21e.png",
+        "Vihāra: Dance Residency Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Anoushka Rahman" ></div>
+        <div class="card-title">
+          Vihāra
+          <div class="sub-title">Dance Residency</div>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/src/kula-artistes-residence.njk
+++ b/src/kula-artistes-residence.njk
@@ -124,28 +124,38 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1719899818/K
         </div>
       </div>
     </div>
-    <div class="even-columns">
-      <div class="left-column">
-        <div class="image-plus card" onclick="location.href='/popularising-the-arts';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718613522/ajji-masthead-desk_uzyz4t.png",
-          "Popularising the Arts Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Pavithra Reddy" ></div>
-          <div class="card-title">Popularising<br />the Arts</div>
+    <div class="even-columns-unlimited">
+
+      <div class="image-plus card size-md" onclick="location.href='/popularising-the-arts';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718613522/ajji-masthead-desk_uzyz4t.png",
+        "Popularising the Arts Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Pavithra Reddy" ></div>
+        <div class="card-title">Popularising<br />the Arts</div>
+      </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/building-a-dance-community';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
+        "Building a Dance Community Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Ravi Shankar" ></div>
+        <div class="card-title">
+          Dance Commons
+          <div class="sub-title">Building a Dance Community</div>
         </div>
       </div>
-      <div class="right-column">
-        <div class="image-plus card" onclick="location.href='/building-a-dance-community';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
-          "Building a Dance Community Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Ravi Shankar" ></div>
-          <div class="card-title">
-            Dance Commons
-            <div class="sub-title">Building a Dance Community</div>
-          </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/dance-residency';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1777342463/dance-residency-masthead-desk_hfr21e.png",
+        "Vihāra: Dance Residency Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Anoushka Rahman" ></div>
+        <div class="card-title">
+          Vihāra
+          <div class="sub-title">Dance Residency</div>
         </div>
       </div>
+
     </div>
   </div>
 </div>

--- a/src/popularising-the-arts.njk
+++ b/src/popularising-the-arts.njk
@@ -484,31 +484,41 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1726534956/p
         </div>
       </div>
     </div>
-    <div class="even-columns">
-      <div class="left-column">
-        <div class="image-plus card" onclick="location.href='/kula-artistes-residence';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
-          "Kula: Artistes’ Residence Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Unknown" ></div>
-          <div class="card-title">
-            Kula
-            <div class="sub-title">Artistes’ Residence</div>
-          </div>
+    <div class="even-columns-unlimited">
+
+      <div class="image-plus card size-md" onclick="location.href='/kula-artistes-residence';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
+        "Kula: Artistes’ Residence Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Unknown" ></div>
+        <div class="card-title">
+          Kula
+          <div class="sub-title">Artistes’ Residence</div>
         </div>
       </div>
-      <div class="right-column">
-        <div class="image-plus card" onclick="location.href='/building-a-dance-community';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
-          "Building a Dance Community Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Ravi Shankar" ></div>
-          <div class="card-title">
-            Dance Commons
-            <div class="sub-title">Building a Dance Community</div>
-          </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/building-a-dance-community';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
+        "Building a Dance Community Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Ravi Shankar" ></div>
+        <div class="card-title">
+          Dance Commons
+          <div class="sub-title">Building a Dance Community</div>
         </div>
       </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/dance-residency';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1777342463/dance-residency-masthead-desk_hfr21e.png",
+        "Vihāra: Dance Residency Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Anoushka Rahman" ></div>
+        <div class="card-title">
+          Vihāra
+          <div class="sub-title">Dance Residency</div>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>

--- a/src/village-outreach.njk
+++ b/src/village-outreach.njk
@@ -120,31 +120,41 @@ OGImage: "https://res.cloudinary.com/nrityagram/image/upload/w_600/v1569846362/v
         </div>
       </div>
     </div>
-    <div class="even-columns">
-      <div class="left-column">
-        <div class="image-plus card" onclick="location.href='/kula-artistes-residence';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
-          "Kula: Artistes’ Residence Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Unknown" ></div>
-          <div class="card-title">
-            Kula
-            <div class="sub-title">Artistes’ Residence</div>
-          </div>
+    <div class="even-columns-unlimited">
+
+      <div class="image-plus card size-md" onclick="location.href='/kula-artistes-residence';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1719899818/Kula-masthead-desk_ktpdi9.png",
+        "Kula: Artistes’ Residence Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Unknown" ></div>
+        <div class="card-title">
+          Kula
+          <div class="sub-title">Artistes’ Residence</div>
         </div>
       </div>
-      <div class="right-column">
-        <div class="image-plus card" onclick="location.href='/building-a-dance-community';">
-          {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
-          "Building a Dance Community Card",
-          ["560", "768"] %}
-          <div class="credit" data-image-credit="Ravi Shankar" ></div>
-          <div class="card-title">
-            Dance Commons
-            <div class="sub-title">Building a Dance Community</div>
-          </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/building-a-dance-community';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1718616963/dance-commons-masthead-desk_qs6rlh.png",
+        "Building a Dance Community Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Ravi Shankar" ></div>
+        <div class="card-title">
+          Dance Commons
+          <div class="sub-title">Building a Dance Community</div>
         </div>
       </div>
+
+      <div class="image-plus card size-md" onclick="location.href='/dance-residency';">
+        {% image "https://res.cloudinary.com/nrityagram/image/upload/v1777342463/dance-residency-masthead-desk_hfr21e.png",
+        "Vihāra: Dance Residency Card",
+        ["560", "768"] %}
+        <div class="credit" data-image-credit="Anoushka Rahman" ></div>
+        <div class="card-title">
+          Vihāra
+          <div class="sub-title">Dance Residency</div>
+        </div>
+      </div>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds a Dance Residency card to the bottom card grid on community.njk, village-outreach.njk, popularising-the-arts.njk, kula-artistes-residence.njk, and building-a-dance-community.njk, restructuring the last row into a 3-card layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vihāra: Dance Residency cards linking to the new dance residency page across relevant community and arts pages.
  * Expanded related-content sections to display three flexible cards for easier browsing.

* **Content Updates**
  * Updated US representation details for Ensemble, including agency, email address, and website.
  * Corrected Sridhar Mahadevan’s biography by removing his former Co-Founder and Chief Operating Officer titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->